### PR TITLE
fix: Standardize age group formatting and restore comprehensive tests

### DIFF
--- a/backend/src/mm_to_json/mm_to_json.py
+++ b/backend/src/mm_to_json/mm_to_json.py
@@ -958,12 +958,9 @@ class Event:
         if self.min_age == 0 and self.max_age >= 109:
             age_str = "Open"
         elif self.min_age == 0:
-            # Specific logic for "8 & Under" vs "6 & Under"
-            # If max_age is 6, return "6 & Under"
-            # If max_age is 8, return "8 & Under"
-            age_str = f"{self.max_age} & Under"
+            age_str = f"{self.max_age} & under"
         elif self.max_age >= 109:
-            age_str = f"{self.min_age} & Over"
+            age_str = f"{self.min_age} & over"
         else:
             # Strict format "Min-Max" e.g. "11-12"
             age_str = f"{self.min_age}-{self.max_age}"

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -502,9 +502,8 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
                 g = gender_map.get(e.get("Event_sex", "").strip(), e.get("Event_sex", ""))
                 d = e.get("Event_dist", "")
                 s = stroke_map.get(e.get("Event_stroke", "").strip(), e.get("Event_stroke", ""))
-                low = e.get("Low_age", "")
-                high = e.get("High_Age", "")
-                name = f"{g} {low}-{high} {d} {s}"
+                age_group = self._format_age(e.get("Low_age"), e.get("High_Age"))
+                name = f"{g} {age_group} {d} {s}"
                 events_map[e_no] = name
 
         result = []
@@ -637,9 +636,8 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
                 g = gender_map.get(e.get("Event_sex", "").strip(), e.get("Event_sex", ""))
                 d = e.get("Event_dist", "")
                 s = stroke_map.get(e.get("Event_stroke", "").strip(), e.get("Event_stroke", ""))
-                low = e.get("Low_age", "")
-                high = e.get("High_Age", "")
-                name = f"{g} {low}-{high} {d} {s}"
+                age_group = self._format_age(e.get("Low_age"), e.get("High_Age"))
+                name = f"{g} {age_group} {d} {s}"
                 events_map[e_no] = name
 
         result = []

--- a/backend/src/verify_report_generation.py
+++ b/backend/src/verify_report_generation.py
@@ -38,12 +38,13 @@ def load_mdb(db_path):
 
 def verify_report_generation():
     # 1. Load Data
-    data_path = "/app/data/2025-07-12 FAST @ DP-Meet2-MeetMgr.mdb"
+    data_path = "data/after meet - TVSL Championship Meet July 19, 2025.mdb"
     if not os.path.exists(data_path):
-        print(f"Error: {data_path} not found.")
-        # Fallback to local path if running outside docker but with mapped paths?
-        # Just use absolute container path
-        return
+        # Try one level up if run from src/
+        data_path = "../data/after meet - TVSL Championship Meet July 19, 2025.mdb"
+        if not os.path.exists(data_path):
+            print(f"Error: {data_path} not found.")
+            return
 
     print("Loading MDB...")
     table_data = load_mdb(data_path)
@@ -82,7 +83,10 @@ def verify_report_generation():
     )
 
     # 4. Render PDF
-    output_pdf = "/app/data/example_reports/verification_entries_v5.pdf"
+    output_pdf = "data/example_reports/verification_entries_v5.pdf"
+    if not os.path.exists("data/example_reports"):
+        output_pdf = "../data/example_reports/verification_entries_v5.pdf"
+
     print(f"Rendering PDF to {output_pdf}...")
     renderer = PDFRenderer(output_pdf, config)
     renderer.render(report_data)

--- a/backend/tests/test_reporting_comprehensive.py
+++ b/backend/tests/test_reporting_comprehensive.py
@@ -1,0 +1,106 @@
+import unittest
+
+from mm_to_json.mm_to_json import MmToJsonConverter
+from mm_to_json.reporting.extractor import ReportDataExtractor
+
+
+class TestReportingComprehensive(unittest.TestCase):
+    def setUp(self):
+        # Mocking the MmToJsonConverter with minimal data for all tables
+        self.table_data = {
+            "Meet": [
+                {
+                    "Meet_name1": "Test Meet",
+                    "Meet_location": "Test Pool",
+                    "Meet_start": "2026-02-13",
+                    "Meet_end": "2026-02-13",
+                }
+            ],
+            "Session": [
+                {"Sess_ptr": 1, "Sess_no": 1, "Sess_name": "Session 1", "Sess_day": 1, "Sess_starttime": 32400}
+            ],
+            "Sessitem": [{"Sess_ptr": 1, "Event_ptr": 1, "Sess_order": 1, "Sess_rnd": "F"}],
+            "Event": [
+                {
+                    "Event_no": 1,
+                    "Event_ptr": 1,
+                    "Ind_rel": "I",
+                    "Event_gender": "M",
+                    "Event_sex": "Boys",
+                    "Event_dist": 50,
+                    "Event_stroke": "A",
+                    "Low_age": 11,
+                    "High_age": 12,
+                    "Num_finlanes": 6,
+                    "Event_rounds": 1,
+                }
+            ],
+            "Athlete": [
+                {"Ath_no": 1, "First_name": "Alice", "Last_name": "Athlete", "Ath_age": 11, "Team_no": 1, "Sex": "F"},
+                {"Ath_no": 2, "First_name": "Bob", "Last_name": "Swimmer", "Ath_age": 12, "Team_no": 1, "Sex": "M"},
+            ],
+            "Team": [{"Team_no": 1, "Team_abbr": "TST", "Team_name": "Test Team"}],
+            "Entry": [
+                {
+                    "Event_ptr": 1,
+                    "Ath_no": 1,
+                    "Fin_heat": 1,
+                    "Fin_lane": 1,
+                    "ConvSeed_time": 30.5,
+                    "Fin_Time": 29.5,
+                    "Fin_Stat": "",
+                },
+                {
+                    "Event_ptr": 1,
+                    "Ath_no": 2,
+                    "Fin_heat": 1,
+                    "Fin_lane": 2,
+                    "ConvSeed_time": 32.0,
+                    "Fin_Time": 31.0,
+                    "Fin_Stat": "",
+                },
+            ],
+            "Relay": [],
+            "RelayNames": [],
+            "Divisions": [],
+        }
+        self.converter = MmToJsonConverter(table_data=self.table_data)
+        self.extractor = ReportDataExtractor(self.converter)
+
+    def test_extract_psych_sheet_data(self):
+        data = self.extractor.extract_psych_sheet_data()
+        self.assertEqual(data["meet_name"], "Test Meet")
+        self.assertEqual(len(data["groups"]), 1)
+        group = data["groups"][0]
+        self.assertIn("Event 1", group["header"])
+        entries = group["items"][0]["sub_items"]
+        self.assertEqual(len(entries), 2)
+        # Sorted by seed time: 30.5 should be first
+        self.assertEqual(entries[0]["time"], "30.50")
+        self.assertEqual(entries[1]["time"], "32.00")
+
+    def test_extract_timer_sheets_data(self):
+        data = self.extractor.extract_timer_sheets_data()
+        self.assertEqual(len(data["groups"]), 1)
+        group = data["groups"][0]
+        self.assertIn("Heat 1", group["header"])
+        entries = group["items"][0]["sub_items"]
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0]["lane"], "1")
+        self.assertEqual(entries[1]["lane"], "2")
+
+    def test_extract_results_data(self):
+        data = self.extractor.extract_results_data()
+        self.assertEqual(len(data["groups"]), 1)
+        group = data["groups"][0]
+        entries = group["items"][0]["sub_items"]
+        self.assertEqual(len(entries), 2)
+        # Sorted by results time: 29.50 should be first
+        self.assertEqual(entries[0]["time"], "29.50")
+        self.assertEqual(entries[0]["place"], "1")
+        self.assertEqual(entries[1]["time"], "31.00")
+        self.assertEqual(entries[1]["place"], "2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web-client/app/events/page.tsx
+++ b/web-client/app/events/page.tsx
@@ -1,14 +1,8 @@
 import { getEvents } from "@/app/actions";
 import { AppSidebar } from "@/components/app-sidebar";
 import { EventsManager } from "@/components/events-manager";
-import type { SwimEvent as UIEvent } from "@/lib/swim-meet-types";
-
-function formatAgeGroup(low: number, high: number): string {
-	if (low === 0 && high === 0) return "Open";
-	if (low === 0 && high > 0) return `${high} & under`;
-	if (low > 0 && (high === 0 || high >= 99)) return `${low} & over`;
-	return `${low}-${high}`;
-}
+import type { SwimEvent } from "@/lib/swim-meet-types";
+import { formatAgeGroup } from "@/lib/utils";
 
 export const dynamic = "force-dynamic";
 
@@ -25,7 +19,7 @@ interface ServerEvent {
 }
 
 export default async function EventsPage() {
-	let mappedEvents: UIEvent[] = [];
+	let mappedEvents: SwimEvent[] = [];
 
 	try {
 		const list = (await getEvents()) as unknown as { events: ServerEvent[] };

--- a/web-client/lib/utils.ts
+++ b/web-client/lib/utils.ts
@@ -8,3 +8,10 @@ export function cn(...inputs: ClassValue[]) {
 export function setCookie(name: string, value: string, maxAgeSeconds: number) {
 	document.cookie = `${name}=${value}; path=/; max-age=${maxAgeSeconds}`;
 }
+
+export function formatAgeGroup(low: number, high: number): string {
+	if (low === 0 && high === 0) return "Open";
+	if (low === 0 && high > 0) return `${high} & under`;
+	if (low > 0 && (high === 0 || high >= 99)) return `${low} & over`;
+	return `${low}-${high}`;
+}


### PR DESCRIPTION
This PR integrates the required age group formatting fixes (e.g., '6 & under' instead of '0-6') and restores the comprehensive backend tests that were inadvertently removed in a previous PR attempt. These changes have been verified locally and do not introduce the regressions found in PR #33.