### PR TITLE
fix: Show all 6 lanes in Judge View (Issue #57)

### DIFF
--- a/mobile-judge-app/App.tsx
+++ b/mobile-judge-app/App.tsx
@@ -108,15 +108,21 @@ export default function App() {
         data={swimmers}
         keyExtractor={(item) => item.id.toString()}
         renderItem={({ item }) => (
-          <TouchableOpacity style={styles.swimmerCard} onPress={() => handleDQ(item)}>
-            <View style={styles.laneCircle}>
+          <TouchableOpacity
+            style={[styles.swimmerCard, item.empty && styles.emptyCard]}
+            onPress={() => !item.empty && handleDQ(item)}
+            disabled={item.empty}
+          >
+            <View style={[styles.laneCircle, item.empty && styles.emptyLane]}>
               <Text style={styles.laneText}>{item.lane}</Text>
             </View>
             <View style={styles.swimmerInfo}>
-              <Text style={styles.swimmerName}>{item.name}</Text>
+              <Text style={[styles.swimmerName, item.empty && styles.emptyText]}>{item.name}</Text>
               <Text style={styles.teamName}>{item.team}</Text>
             </View>
-            <Text style={styles.dqTrigger}>{item.dq_code ? item.dq_code : 'TAP TO DQ'}</Text>
+            {!item.empty && (
+              <Text style={styles.dqTrigger}>{item.dq_code ? item.dq_code : 'TAP TO DQ'}</Text>
+            )}
           </TouchableOpacity>
         )}
       />
@@ -382,5 +388,16 @@ const styles = StyleSheet.create({
   dqDescription: {
     flex: 1,
     fontSize: 16,
+  },
+  emptyCard: {
+    backgroundColor: '#FAFAFA',
+    borderColor: '#E0E0E0',
+  },
+  emptyLane: {
+    backgroundColor: '#CCCCCC',
+  },
+  emptyText: {
+    color: '#999999',
+    fontStyle: 'italic',
   }
 });

--- a/mobile-judge-app/src/database/db.web.ts
+++ b/mobile-judge-app/src/database/db.web.ts
@@ -71,19 +71,38 @@ export const getHeatsByEvent = (eventId: number) => {
 export const getSwimmersByHeat = (heatId: number) => {
   const swimmers = _testData.swimmers.filter(s => s.heat_id === heatId);
 
-  // Merge with DQs
-  return swimmers.map(s => {
-    const dq = mockDQs.find(d => d.swimmerId === s.id);
-    return {
-      ...s,
-      dq_code: dq ? dq.dqCode : null
-    };
-  });
+  // Create a map for quick lookup
+  const swimmerMap = new Map(swimmers.map(s => [s.lane, s]));
+
+  const result = [];
+  // Assume 6 lanes for now (could be dynamic based on event settings later)
+  for (let lane = 1; lane <= 6; lane++) {
+    if (swimmerMap.has(lane)) {
+      const s = swimmerMap.get(lane)!;
+      const dq = mockDQs.find(d => d.swimmerId === s.id);
+      result.push({
+        ...s,
+        dq_code: dq ? dq.dqCode : null,
+        empty: false
+      });
+    } else {
+      result.push({
+        id: `empty-${heatId}-${lane}`,
+        heat_id: heatId,
+        lane: lane,
+        name: 'Empty',
+        team: '',
+        dq_code: null,
+        empty: true
+      });
+    }
+  }
+  return result;
 };
 
 export const saveDQ = (eventId: number, swimmerId: number, dqCode: string) => {
   console.log('Web Mock DQ Saved:', { eventId, swimmerId, dqCode });
-  
+
   // Call runSync to support test verification
   getDb().runSync(
     'INSERT INTO dqs (event_id, swimmer_id, dq_code, sync_status) VALUES (?, ?, ?, ?)',


### PR DESCRIPTION
Fixes #57

## Description
This PR addresses the issue where heats with fewer than 6 swimmers would only show the occupied lanes, hiding the empty ones. This caused inconsistent UI and confusion about lane assignments.

## Fix
- Modified `getSwimmersByHeat` in `db.web.ts` to ensuring it always returns 6 objects (lanes 1-6).
- If a lane is empty, a placeholder object with `empty: true` is returned.
- Updated `App.tsx` (Judge View) to handle `empty` swimmers by invalidating the `onPress` action and styling the row as dimmed/disabled.

## Verification
- Reproduced the issue locally (only saw occupied lanes).
- Verified the fix locally via browser automation (saw 6 lanes, with empty ones correctly styled).
