### PR TITLE
feat: DQ Notes UI and storage (Issue #58)

### DIFF
--- a/mobile-judge-app/App.tsx
+++ b/mobile-judge-app/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { StyleSheet, Text, View, FlatList, TouchableOpacity, Modal, SafeAreaView, ScrollView } from 'react-native';
+import { StyleSheet, Text, View, FlatList, TouchableOpacity, Modal, SafeAreaView, ScrollView, TextInput } from 'react-native';
 import { initDatabase, seedData, getEvents, getHeatsByEvent, getSwimmersByHeat, saveDQ, getPendingDQs } from './src/database/db';
 import dqCodes from './src/config/dqCodes.json';
 import { ProgramView } from './src/components/ProgramView';
@@ -26,6 +26,7 @@ export default function App() {
   const [dqModalVisible, setDqModalVisible] = useState(false);
   const [selectedSwimmer, setSelectedSwimmer] = useState<any>(null);
   const [selectedLeg, setSelectedLeg] = useState<number | undefined>(undefined);
+  const [dqNote, setDqNote] = useState('');
   const [pendingCount, setPendingCount] = useState(0);
   const [programMode, setProgramMode] = useState(false); // Toggle state
 
@@ -63,11 +64,12 @@ export default function App() {
   const handleDQ = (swimmer: any, leg?: number) => {
     setSelectedSwimmer(swimmer);
     setSelectedLeg(leg);
+    setDqNote(''); // Reset note
     setDqModalVisible(true);
   };
 
   const submitDQ = (code: string) => {
-    saveDQ(selectedEvent ? selectedEvent.id : 0, selectedSwimmer.id, code, selectedLeg);
+    saveDQ(selectedEvent ? selectedEvent.id : 0, selectedSwimmer.id, code, selectedLeg, dqNote);
     setDqModalVisible(false);
     updatePendingCount();
 
@@ -186,7 +188,6 @@ export default function App() {
           onSelectSwimmer={(swimmer, event, heat) => {
             setSelectedEvent(event);
             setSelectedHeat(heat);
-            // Program View might need leg support too. For now, assume it's basic.
             handleDQ(swimmer);
           }}
           refreshTrigger={pendingCount}
@@ -237,6 +238,15 @@ export default function App() {
               <TouchableOpacity onPress={() => setDqModalVisible(false)}>
                 <Text style={styles.closeButton}>CANCEL</Text>
               </TouchableOpacity>
+            </View>
+            <View style={styles.noteContainer}>
+              <TextInput
+                style={styles.noteInput}
+                placeholder="Add notes here (optional)"
+                value={dqNote}
+                onChangeText={setDqNote}
+                multiline
+              />
             </View>
             <ScrollView>
               {Object.entries(dqCodes).map(([category, codes]) => (
@@ -404,6 +414,19 @@ const styles = StyleSheet.create({
   closeButton: {
     color: COLORS.accent,
     fontWeight: 'bold',
+  },
+  noteContainer: {
+    padding: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.lightGray,
+  },
+  noteInput: {
+    borderWidth: 1,
+    borderColor: COLORS.secondary,
+    borderRadius: 5,
+    padding: 10,
+    minHeight: 60,
+    textAlignVertical: 'top',
   },
   dqCategory: {
     padding: 10,

--- a/mobile-judge-app/src/database/db.web.ts
+++ b/mobile-judge-app/src/database/db.web.ts
@@ -121,25 +121,26 @@ export const getSwimmersByHeat = (heatId: number) => {
   return result;
 };
 
-export const saveDQ = (eventId: number, swimmerId: number, dqCode: string, leg?: number) => {
-  console.log('Web Mock DQ Saved:', { eventId, swimmerId, dqCode, leg });
+export const saveDQ = (eventId: number, swimmerId: number, dqCode: string, leg?: number, notes?: string) => {
+  console.log('Web Mock DQ Saved:', { eventId, swimmerId, dqCode, leg, notes });
 
   // Call runSync to support test verification
   getDb().runSync(
-    'INSERT INTO dqs (event_id, swimmer_id, dq_code, leg, sync_status) VALUES (?, ?, ?, ?, ?)',
+    'INSERT INTO dqs (event_id, swimmer_id, dq_code, leg, notes, sync_status) VALUES (?, ?, ?, ?, ?, ?)',
     eventId,
     swimmerId,
     dqCode,
     leg || null,
+    notes || '',
     'pending'
   );
 
   // Update in-memory store
   const existingIndex = mockDQs.findIndex(d => d.swimmerId === swimmerId && d.leg === leg);
   if (existingIndex >= 0) {
-    mockDQs[existingIndex] = { eventId, swimmerId, dqCode, leg, timestamp: new Date().toISOString() };
+    mockDQs[existingIndex] = { eventId, swimmerId, dqCode, leg, notes, timestamp: new Date().toISOString() };
   } else {
-    mockDQs.push({ eventId, swimmerId, dqCode, leg, timestamp: new Date().toISOString() });
+    mockDQs.push({ eventId, swimmerId, dqCode, leg, notes, timestamp: new Date().toISOString() });
   }
   return { changes: 1 };
 };


### PR DESCRIPTION
Fixes #58

## Description
This PR adds an optional text input field to the DQ Modal, allowing judges to add context or notes to their calls.

## Changes
- Updated `db.web.ts` to support storing a `notes` string in the DQ table.
- Updated `App.tsx` to include a `TextInput` in the DQ Modal.
- Updated `submitDQ` to pass the note to the backend.

## Verification
- Verified locally with browser automation.
- Confirmed that the input field appears and accepts text.
