### PR TITLE
feat: stroke-aware DQ sorting (Issue #59)

### DIFF
--- a/mobile-judge-app/App.tsx
+++ b/mobile-judge-app/App.tsx
@@ -16,6 +16,43 @@ const COLORS = {
   success: '#2A9D8F'
 };
 
+const getStrokeForEvent = (event: any, leg?: number) => {
+  if (!event) return null;
+  if (event.isRelay && leg) {
+    if (event.stroke === 'Medley Relay' || event.name.includes('Medley')) {
+      switch (leg) {
+        case 1: return 'Back';
+        case 2: return 'Breast';
+        case 3: return 'Fly';
+        case 4: return 'Free';
+      }
+    }
+    return 'Free'; // Free Relay
+  }
+  return event.stroke || 'Free';
+};
+
+const getOrderedDQCategories = (currentStroke: string | null) => {
+  const categories = Object.keys(dqCodes);
+  if (!currentStroke) return categories;
+
+  const priorityMap: { [key: string]: string } = {
+    'Fly': 'butterfly',
+    'Back': 'backstroke',
+    'Breast': 'breaststroke'
+  };
+
+  const targetCategory = priorityMap[currentStroke];
+
+  if (targetCategory) {
+    return [
+      targetCategory,
+      ...categories.filter(c => c !== targetCategory)
+    ];
+  }
+  return categories;
+};
+
 export default function App() {
   const [currentScreen, setCurrentScreen] = useState<'events' | 'heats' | 'judge' | 'program'>('events');
   const [selectedEvent, setSelectedEvent] = useState<any>(null);
@@ -170,6 +207,9 @@ export default function App() {
     </View>
   );
 
+  const currentStroke = getStrokeForEvent(selectedEvent, selectedLeg);
+  const orderedDQCategories = getOrderedDQCategories(currentStroke);
+
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.statusBar}>
@@ -249,10 +289,10 @@ export default function App() {
               />
             </View>
             <ScrollView>
-              {Object.entries(dqCodes).map(([category, codes]) => (
+              {orderedDQCategories.map((category) => (
                 <View key={category} style={styles.dqCategory}>
                   <Text style={styles.categoryTitle}>{category.toUpperCase()}</Text>
-                  {codes.map((item: any) => (
+                  {dqCodes[category as keyof typeof dqCodes].map((item: any) => (
                     <TouchableOpacity
                       key={item.code}
                       style={styles.dqItem}

--- a/mobile-judge-app/src/database/db.web.ts
+++ b/mobile-judge-app/src/database/db.web.ts
@@ -37,7 +37,8 @@ const generateTestData = () => {
       id: i,
       number: i,
       name: `${gender} ${ageGroup} ${distance} ${stroke}`,
-      isRelay: isRelay
+      isRelay: isRelay,
+      stroke: isRelay ? 'Medley Relay' : stroke // Store stroke for sorting logic
     });
 
     // Generate 2 heats per event


### PR DESCRIPTION
Fixes #59

## Description
This PR implements stroke-aware sorting for DQ codes in the Judge View modal.

## Changes
- **Database (`db.web.ts`)**: Added `stroke` property to event objects (including 'Medley Relay').
- **UI (`App.tsx`)**:
    - Added `getStrokeForEvent` helper to determine the relevant stroke for the current event or relay leg.
    - Added `getOrderedDQCategories` to sort the DQ categories, placing the matching stroke's category at the top.
    - Updated `Modal` rendering to use the sorted categories.

## Verification
- Verified locally with browser automation.
- Confirmed "BREASTSTROKE" category appears first for Breaststroke events.
- Confirmed "BUTTERFLY" category appears first for the Butterfly leg of a Medley Relay.
