### PR TITLE
fix: set build timestamps to Pacific Time (PT)

### DIFF
--- a/meet-program-viewer/App.tsx
+++ b/meet-program-viewer/App.tsx
@@ -4,7 +4,7 @@ import { ProgramList } from './src/components/ProgramList';
 import { useMeetData } from './src/hooks/useMeetData';
 import { COLORS } from './src/constants/colors';
 
-const BUILD_TIME = "02/20/2026, 10:00:05 PM"; // Fixed build time
+const BUILD_TIME = "02/20/2026, 11:01:50 PM PT"; // Fixed build time
 
 export default function App() {
     const { events, isResults, loading } = useMeetData();

--- a/meet-program-viewer/inject-build-time.js
+++ b/meet-program-viewer/inject-build-time.js
@@ -7,6 +7,7 @@ let content = fs.readFileSync(appTsxPath, 'utf8');
 
 const now = new Date();
 const formattedTime = now.toLocaleString('en-US', {
+    timeZone: 'America/Los_Angeles',
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
@@ -14,7 +15,7 @@ const formattedTime = now.toLocaleString('en-US', {
     minute: '2-digit',
     second: '2-digit',
     hour12: true,
-});
+}) + ' PT';
 
 // Regex to find and replace the BUILD_TIME constant declaration
 const regex = /const BUILD_TIME = ".*";/g;

--- a/mobile-judge-app/App.tsx
+++ b/mobile-judge-app/App.tsx
@@ -65,7 +65,7 @@ const getOrderedDQCategories = (currentStroke: string | null) => {
   return categories;
 };
 
-const BUILD_TIME = "02/20/2026, 10:00:07 PM"; // Fixed build time
+const BUILD_TIME = "02/20/2026, 11:01:50 PM PT"; // Fixed build time
 
 export default function App() {
   const [currentScreen, setCurrentScreen] = useState<'events' | 'heats' | 'judge' | 'program'>('events');

--- a/mobile-judge-app/inject-build-time.js
+++ b/mobile-judge-app/inject-build-time.js
@@ -7,6 +7,7 @@ let content = fs.readFileSync(appTsxPath, 'utf8');
 
 const now = new Date();
 const formattedTime = now.toLocaleString('en-US', {
+    timeZone: 'America/Los_Angeles',
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
@@ -14,7 +15,7 @@ const formattedTime = now.toLocaleString('en-US', {
     minute: '2-digit',
     second: '2-digit',
     hour12: true,
-});
+}) + ' PT';
 
 // Regex to find and replace the BUILD_TIME constant declaration
 const regex = /const BUILD_TIME = ".*";/g;


### PR DESCRIPTION
This PR fixes the build timestamp injected at build time to always format in Pacific Time (PT) and explicitly append `" PT"` to the footer of both the Mobile Judge App and Meet Program Viewer. 

Fixes user request.