### PR TITLE
fix: Meet Program layout refinements and smart wrapping (#238)

### DIFF
--- a/backend/src/mm_to_json/reporting/templates/_base_report.j2
+++ b/backend/src/mm_to_json/reporting/templates/_base_report.j2
@@ -24,12 +24,12 @@
     <div id="header" class="header-container">
         <div class="header-top">
             <div class="header-left">
-                <span class="header-meet-name">{{ meet_name|default('Tri-Valley Swim League') }}</span> - 
-                <span class="header-sub-title">{{ sub_title }}</span>
+                <div class="header-meet-name">{{ meet_name|default('Tri-Valley Swim League') }}</div>
+                <div class="header-sub-title">{{ sub_title }}</div>
             </div>
             <div class="header-right">
-                <span class="header-timestamp">MM-Tools - {{ generation_time }}</span>
-                <span class="header-page-num">Page <span class="page-counter"></span></span>
+                <div class="header-timestamp">MM-Tools - {{ generation_time }}</div>
+                <div class="header-page-num">Page <span class="page-counter"></span></div>
             </div>
         </div>
     </div>

--- a/backend/src/mm_to_json/reporting/templates/lineups.j2
+++ b/backend/src/mm_to_json/reporting/templates/lineups.j2
@@ -37,8 +37,8 @@
     <div id="header" class="header-container">
         <div class="header-top">
             <div class="header-left">
-                <span class="header-meet-name">{{ meet_name|default('Tri-Valley Swim League') }}</span> - 
-                <span class="header-sub-title">{{ sub_title }}</span>
+                <div class="header-meet-name">{{ meet_name|default('Tri-Valley Swim League') }}</div>
+                <div class="header-sub-title">{{ sub_title }}</div>
             </div>
             <div class="header-right">
                 <span class="header-timestamp">MM-Tools - {{ generation_time }}</span>

--- a/backend/src/mm_to_json/reporting/templates/meet_program.j2
+++ b/backend/src/mm_to_json/reporting/templates/meet_program.j2
@@ -42,9 +42,8 @@
                     
                     {{ macros.render_standard_entry_row(entry, is_zebra, show_dq_lines=show_dq_lines) }}
                     
-                    {# Colspan calculation for relay swimmers #}
-                    {% set base_colspan = 3 if entry.is_relay else 4 %}
-                    {% set final_colspan = base_colspan + (1 if show_dq_lines else 0) %}
+                    {# Colspan calculation for relay swimmers - use full width #}
+                    {% set final_colspan = 5 if show_dq_lines else 4 %}
                     {{ macros.render_relay_swimmers_row(entry, is_zebra, colspan=final_colspan, show_dq_lines=show_dq_lines) }}
                     
                 {% endfor %}

--- a/backend/src/mm_to_json/reporting/templates/report_style.css
+++ b/backend/src/mm_to_json/reporting/templates/report_style.css
@@ -10,7 +10,7 @@
 
 body {
     font-family: "Helvetica", sans-serif;
-    font-size: 9pt;
+    font-size: 10pt; /* Increased from 9pt */
     line-height: 1.1;
     margin: 0;
     padding: 0;
@@ -19,7 +19,7 @@ body {
 #header {
     position: running(header);
     width: 100%;
-    border-bottom: 0.5pt solid #000;
+    border-bottom: 1pt solid #000; /* Increased from 0.5pt */
     padding-bottom: 3pt;
     margin-bottom: 10pt;
 }
@@ -27,15 +27,26 @@ body {
 .header-top {
     width: 100%;
     position: relative;
-    height: 14pt;
+    height: 26pt; /* Increased for two lines */
 }
 
 .header-left {
     position: absolute;
     left: 0;
     bottom: 0;
+    text-align: left;
+}
+
+.header-meet-name {
     font-size: 10pt;
     font-weight: bold;
+    color: #333;
+}
+
+.header-sub-title {
+    font-size: 9pt;
+    font-weight: bold;
+    color: #000;
 }
 
 .header-right {
@@ -43,6 +54,9 @@ body {
     right: 0;
     bottom: 0;
     text-align: right;
+}
+
+.header-timestamp, .header-page-num {
     font-size: 8pt;
     color: #666;
 }
@@ -62,7 +76,7 @@ body {
 .content-container {
     column-count: 2;
     column-gap: 20pt;
-    column-rule: 0.5pt solid #eee;
+    column-rule: 1pt solid #ddd; /* Increased from 0.5pt */
     column-fill: auto;
 }
 
@@ -71,7 +85,7 @@ body {
 }
 
 .event-block {
-    break-inside: avoid;
+    /* break-inside: avoid; REMOVED to allow breaking across columns */
     margin-bottom: 12pt;
     width: 100%;
 }
@@ -81,9 +95,10 @@ body {
     font-weight: bold;
     font-size: 9pt;
     padding: 2pt 4pt;
-    border: 0.5pt solid #ccc;
+    border: 1pt solid #999; /* Increased from 0.5pt */
     margin-bottom: 4pt;
     text-transform: uppercase;
+    break-after: avoid; /* Keep with first heat */
 }
 
 .heat-block {
@@ -93,9 +108,10 @@ body {
 
 .heat-header {
     font-weight: bold;
-    font-size: 8pt;
+    font-size: 8.5pt; /* Increased from 8pt */
     margin-bottom: 2pt;
-    border-bottom: 0.5pt solid #eee;
+    border-bottom: 1pt solid #ccc; /* Increased from 0.5pt */
+    break-after: avoid;
 }
 
 .entries-table {
@@ -105,7 +121,7 @@ body {
 
 .entries-table th {
     text-align: left;
-    font-size: 7pt;
+    font-size: 7.5pt; /* Increased from 7pt */
     color: #666;
     border-bottom: 0.5pt solid #ddd;
     padding: 1pt 2pt;
@@ -119,9 +135,58 @@ body {
     text-align: center;
 }
 
+.entries-table thead {
+    break-after: avoid;
+}
+
+.heat-row-header {
+    break-inside: avoid;
+    break-after: avoid; /* Keep with entries of the heat */
+}
+
+.entry-row {
+    break-inside: avoid;
+}
+
+.relay-swimmers-row {
+    break-inside: avoid;
+}
+
 .entries-table td {
     padding: 1pt 2pt;
     vertical-align: bottom; /* Allow space above the line for handwriting if multiline */
+}
+
+.entry-row td {
+    font-size: 9pt; /* Increased from 8pt */
+}
+
+.zebra-row {
+    background-color: #f9f9f9;
+}
+
+.col-lane { width: 20pt; }
+.col-name { width: auto; }
+.col-age { width: 20pt; text-align: center; }
+.col-team { width: 50pt; } /* Increased from 40pt */
+.col-relay { width: 20pt; text-align: center; }
+.col-time { width: 50pt; text-align: right; }
+.col-dq { width: 70pt; text-align: center; }
+
+.dotted-row td {
+    border-bottom: 0.5pt dotted #999 !important;
+}
+
+.relay-swimmers-row td {
+    font-size: 8.5pt; /* Increased from 7.5pt/8pt */
+    padding-top: 0;
+    padding-bottom: 2pt;
+    color: #333;
+    font-style: italic;
+}
+
+.swimmers-list {
+    padding-left: 8pt;
 }
 
 /* Relay Grid Layout (2x2) */


### PR DESCRIPTION
Next phase of formatting refinements for Meet Programs.

### Improvements
1. **Header Realignment**: Meet Name and Report Title are now on separate lines, both left-aligned. MMTools timestamp and Page numbers are right-aligned.
2. **Relay Space Utilization**: Increased `colspan` for relay swimmers to ensure they use the full width of the column, matching the event header.
3. **Smart Column Wrapping**:
   - Removed `break-inside: avoid` from entire event blocks to allow breaking across columns/pages.
   - Implemented `break-after: avoid` on Event Headers and Heat Headers to ensure the "Event + Table Header + Heat 1" block stays together.
4. **Font Optimization**: Increased base font size to 10pt and entry font size to 9pt (middle ground for better readability).
5. **Visual Weight**:
   - Thickened column rule (vertical separator) to 1pt.
   - Thickened heat title underline to 1pt.
   - Slightly wider team column to accommodate abbreviations.

### Verification
- `just test-backend-fast`: Pass (68/68).
- Manual review of template structure.