### PR TITLE
fix: implement DQ sync to MDB and harden security (#49)

### DIFF
--- a/backend/src/mm_to_json/mdb_writer.py
+++ b/backend/src/mm_to_json/mdb_writer.py
@@ -325,3 +325,63 @@ def add_relay_team(db, relay_id, meet_id, team_id, letter, gender, age_range_cod
     if c.findFirstRow(criteria):
         return c.getCurrentRow().get("RELAY")
     return relay_id
+
+
+def update_entry_status(
+    db,
+    event_ptr,
+    athlete_id,
+    heat,
+    lane,
+    status="DQ",
+    dq_code="",
+    round_type="P",
+    is_relay=False,
+):
+    """
+    Updates the status and DQ code for a specific entry.
+    round_type: 'P' for Prelims, 'F' for Finals, 'S' for Semis.
+    is_relay: If True, updates RELAY table instead of ENTRY.
+    """
+    table_name = "RELAY" if is_relay else "ENTRY"
+    table = db.getTable(table_name)
+    if table is None:
+        raise ValueError(f"{table_name} table not found")
+
+    from java.util import HashMap
+
+    criteria = HashMap()
+    criteria.put("Event_ptr", event_ptr)
+    # In RELAY table it's Relay_no, in ENTRY it's Ath_no
+    id_col = "Relay_no" if is_relay else "Ath_no"
+    criteria.put(id_col, athlete_id)
+
+    # Often we want to match heat/lane too to be safe
+    if heat > 0:
+        col = "Pre_heat" if round_type == "P" else ("Fin_heat" if round_type == "F" else "Sem_heat")
+        criteria.put(col, heat)
+    if lane > 0:
+        col = "Pre_lane" if round_type == "P" else ("Fin_lane" if round_type == "F" else "Sem_lane")
+        criteria.put(col, lane)
+
+    c = table.getDefaultCursor()
+    if c.findFirstRow(criteria):
+        row = c.getCurrentRow()
+
+        # Update status
+        stat_col = "Pre_stat" if round_type == "P" else ("Fin_stat" if round_type == "F" else "Sem_stat")
+        row.put(stat_col, status)
+
+        # Update DQ code if provided
+        if dq_code:
+            code_col = "Pre_dqcode" if round_type == "P" else ("Fin_dqcode" if round_type == "F" else "Sem_dqcode")
+            row.put(code_col, dq_code)
+
+        table.updateRow(row)
+        logger.info(f"Updated DQ status for {'Relay' if is_relay else 'Athlete'} {athlete_id} in Event {event_ptr}")
+        return True
+
+    logger.warning(
+        f"Could not find entry for {'Relay' if is_relay else 'Athlete'} {athlete_id} in Event {event_ptr} (Heat {heat}, Lane {lane})"
+    )
+    return False

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -1625,7 +1625,7 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
             # Parse to validate
             dqs = json.loads(dqs_json)
 
-            # Save to user's dataset directory
+            # Save to user's dataset directory (as backup/log)
             filename = "synced_dqs.json"
             user_path = os.path.join("users", uid, filename)
 
@@ -1638,6 +1638,82 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
             finally:
                 if os.path.exists(tmp_path):
                     os.remove(tmp_path)
+
+            # Update the master database if it's an MDB
+            config = self._load_user_config(context)
+            active_filename = config.get("active_dataset")
+            if active_filename and active_filename.lower().endswith(".mdb"):
+                dataset_path = os.path.join("users", uid, active_filename)
+                if self.storage.exists(dataset_path):
+                    logging.info(f"Syncing DQs to MDB: {dataset_path} for user {uid}")
+
+                    # Download MDB to local temp for writing
+                    with tempfile.NamedTemporaryFile(suffix=".mdb", delete=False) as tmp_mdb:
+                        tmp_mdb_path = tmp_mdb.name
+                        tmp_mdb.close()
+
+                    try:
+                        self.storage.download_file(dataset_path, tmp_mdb_path)
+
+                        # Resolve event pointers and relay status from human-readable numbers
+                        cache, _ = self._load_user_data(context)
+                        event_table = cache.get("event", [])
+                        # Map eventNum (human #) to {ptr, is_relay}
+                        event_info_map = {}
+                        for e in event_table:
+                            # event_no is human #, event_ptr is MDB PK
+                            # mtevent is PK in Schema B
+                            h_num = self._safe_int(e.get("event_no") or e.get("mtevent"))
+                            e_ptr = e.get("event_ptr") or e.get("mtevent")
+                            # Ind_rel is 'R' for relays in Schema A, 'i_r' in Schema B?
+                            is_relay = str(e.get("Ind_rel", e.get("i_r", ""))).upper() == "R"
+
+                            if h_num and e_ptr:
+                                event_info_map[h_num] = {"ptr": e_ptr, "is_relay": is_relay}
+
+                        from mm_to_json import mdb_writer
+
+                        db = mdb_writer.open_db(tmp_mdb_path)
+                        try:
+                            updated_count = 0
+                            for dq in dqs:
+                                # Mobile app sends id, swimmer_id, event_id, dq_code, notes, heat, lane
+                                event_id = dq.get("event_id")
+                                athlete_id = dq.get("swimmer_id")
+                                dq_code = dq.get("dq_code", "")
+                                heat = self._safe_int(dq.get("heat", 0))
+                                lane = self._safe_int(dq.get("lane", 0))
+
+                                info = event_info_map.get(self._safe_int(event_id))
+                                if info and athlete_id:
+                                    if mdb_writer.update_entry_status(
+                                        db,
+                                        info["ptr"],
+                                        athlete_id,
+                                        heat,
+                                        lane,
+                                        status="DQ",
+                                        dq_code=dq_code,
+                                        is_relay=info["is_relay"],
+                                    ):
+                                        updated_count += 1
+
+                            db.close()
+                            # Upload updated MDB back to storage
+                            self.storage.upload_file(tmp_mdb_path, dataset_path)
+
+                            # Force cache invalidation so Next.js/Web-Client sees the DQ
+                            if uid in self._user_cache:
+                                del self._user_cache[uid]
+                            logging.info(f"Successfully updated {updated_count} entries in MDB for {uid}")
+                        finally:
+                            try:
+                                db.close()
+                            except Exception:
+                                pass
+                    finally:
+                        if os.path.exists(tmp_mdb_path):
+                            os.remove(tmp_mdb_path)
 
             logging.info(f"Synced {len(dqs)} DQs for user {uid}")
             return pb2.SyncDQsResponse(success=True, message=f"Synced {len(dqs)} items")

--- a/web-client/app/api/sync-dqs/route.ts
+++ b/web-client/app/api/sync-dqs/route.ts
@@ -6,8 +6,18 @@ export async function POST(request: NextRequest) {
 	const token = searchParams.get("token");
 
 	// Basic security check
-	const secretToken =
-		process.env.DATA_ACCESS_TOKEN || "mmtools-default-secret-2024";
+	const secretToken = process.env.DATA_ACCESS_TOKEN;
+
+	if (!secretToken) {
+		console.error(
+			"CRITICAL: DATA_ACCESS_TOKEN environment variable is missing.",
+		);
+		return NextResponse.json(
+			{ error: "Internal server error" },
+			{ status: 500 },
+		);
+	}
+
 	if (token !== secretToken) {
 		return NextResponse.json({ error: "Unauthorized access" }, { status: 403 });
 	}


### PR DESCRIPTION
Determined that Issue #49 was only partially implemented by recent web-client checkins. While a stateless endpoint was added, the backend synchronization to the master MDB database was missing.

I have now implemented the following:
- Extended `mdb_writer.py` with `update_entry_status` to support low-level MDB updates for DQs.
- Updated gRPC `SyncDQs` in `server.py` to identify the active MDB, resolve event pointers, and persist DQs to the database.
- Hardened security in `/api/sync-dqs` by removing the fallback token.

Fixes #49