### PR TITLE
fix: add storage.googleapis.com to judge app trusted hosts and update workflow

### DIFF
--- a/.agent/skills/github-workflow/SKILL.md
+++ b/.agent/skills/github-workflow/SKILL.md
@@ -16,8 +16,13 @@ description: Mandatory practices for GitHub workflows and session continuity in 
   - **Security**: Secret/PII safety check.
   - **Testing**: How will we verify success?
 
-### Phase 2: Surgical Implementation
+### Phase 3: Surgical Implementation
+- **Local Verification (Mandatory Pre-Push)**: Before running `git push`, you MUST execute the following to catch whitespace, linting, and formatting errors:
+  - `just fix`: This will automatically resolve most formatting issues across the project.
+  - `just lint`: Verify that no manual fixes are required.
+  - `just test-backend-fast` and `cd web-client && npm test`: Ensure core logic is still passing.
 - **Separate Branches**: NEVER push to `main`. Use `feat/*` or `fix/*`.
+
 - **Code Preservation**: Preserve all existing comments, whitespace, and formatting in `old_string`. Do not refactor unrelated code.
 - **Documentation**: All new logic MUST include explicit type hints and Google-style docstrings.
 - **Dependency Management**: Use `uv` (Python) or `npm` (JS) and run lockfile updates immediately after any change.

--- a/mobile-judge-app/src/services/dataLoader.ts
+++ b/mobile-judge-app/src/services/dataLoader.ts
@@ -5,6 +5,7 @@ const ALLOWED_HOSTS = [
 	"localhost",
 	"127.0.0.1",
 	"pfisherogden.github.io",
+	"storage.googleapis.com",
 	"example.com", // For testing
 ];
 


### PR DESCRIPTION
This PR fixes the "Blocked untrusted program URL" error in the Mobile Judge App and updates the internal development workflow.

### **Bug Fix:**
- Added `storage.googleapis.com` to the `ALLOWED_HOSTS` list in `dataLoader.ts`. This allows the mobile app to load meet programs published to Google Cloud Storage in the production environment.

### **Workflow Improvement:**
- Updated the `github-workflow` skill to include a **Mandatory Pre-Push Local Verification** step. This mandates running `just fix` and `just lint` locally to catch formatting and whitespace issues before they reach GitHub CI, reducing turnaround time and CI noise.

Verified locally: `just lint` and `npm test` pass.