### PR TITLE
fix: resolve GCS 403 by improving signed URL logic and avoiding token collisions

### DIFF
--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -1611,11 +1611,13 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
             program_url = self.storage.get_url(user_pub_path)
             token = os.getenv("DATA_ACCESS_TOKEN", "mmtools-default-secret-2024")
 
-            # Append token to program_url
-            if "?" in program_url:
-                program_url = f"{program_url}&token={token}"
-            else:
-                program_url = f"{program_url}?token={token}"
+            # Append token to program_url ONLY if it's not already a signed GCS URL
+            # Signed GCS URLs contain 'X-Goog-Algorithm'
+            if "X-Goog-Algorithm" not in program_url:
+                if "?" in program_url:
+                    program_url = f"{program_url}&token={token}"
+                else:
+                    program_url = f"{program_url}?token={token}"
 
             # Sync URL points to the frontend API which proxies to gRPC SyncDQs
             # Use frontend_url from request if provided, otherwise environment variables

--- a/backend/src/storage_provider.py
+++ b/backend/src/storage_provider.py
@@ -137,7 +137,12 @@ class GCSStorageProvider(StorageProvider):
         blob = self.bucket.blob(remote_path)
         try:
             # Try to generate signed URL (requires credentials with service account)
-            return blob.generate_signed_url(expiration=3600, method="GET")
-        except Exception:
+            # Use service_account_email if provided via credentials
+            url = blob.generate_signed_url(expiration=3600, method="GET", version="v4")
+            logger.info(f"Generated signed URL for {remote_path}")
+            return url
+        except Exception as e:
             # Fallback to public URL
+            logger.warning(f"Failed to generate signed URL for {remote_path}: {e}")
+            logger.info(f"Falling back to public URL for {remote_path}: {blob.public_url}")
             return blob.public_url


### PR DESCRIPTION
This PR addresses the `403 Forbidden` error when fetching program data in the Judge App.

### **Root Cause:**
1.  **Improper Token Appending**: The backend was unconditionally appending `?token=...` to the program URL. However, GCS signed URLs already contain their own query parameters. Appending a second `?` (or a `&` that interferes with the GCS signature) caused GCS to reject the request with a 403.
2.  **Signed URL Visibility**: Improved logging in `GCSStorageProvider` to track whether signed URLs are successfully generated or if the system is falling back to public URLs.

### **Fixes:**
- **Smart Token Logic**: Updated `PublishMeetData` in `server.py` to only append the `DATA_ACCESS_TOKEN` if the URL is **not** a signed GCS URL (identified by the presence of `X-Goog-Algorithm`). Signed URLs already provide secure access to the blob.
- **Enhanced GCS Logging**: Added detailed info and warning logs to `GCSStorageProvider.get_url` to aid in future production debugging.
- **V4 Signing**: Switched to V4 signing explicitly in the GCS provider for better compatibility.

Verified locally: All tests passing. Post-deployment monitoring of backend logs is recommended to confirm successful signing.

Fixes #290