### PR TITLE
fix: resolve production failed-to-fetch via CORS and double-encoding issues

### DIFF
--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -1659,10 +1659,11 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
 
             sync_url = f"{frontend_base}/api/sync-dqs?token={token}&uid={uid}"
 
-            # Nested URLs must be fully encoded to be valid as a query parameter value.
-            # We use safe="" to ensure EVERYTHING including / and : is encoded for the final link.
-            encoded_program = urllib.parse.quote(program_url, safe="")
-            encoded_sync = urllib.parse.quote(sync_url, safe="")
+            # Nested URLs must be encoded to be valid as a query parameter value.
+            # We use safe="/:?=&" to ensure we don't double-encode already encoded parts
+            # while still keeping the nested URL safe for the outer URL.
+            encoded_program = urllib.parse.quote(program_url, safe="/:?=&")
+            encoded_sync = urllib.parse.quote(sync_url, safe="/:?=&")
 
             base_url = "https://pfisherogden.github.io/MeetManager-Tools/judge"
             judge_app_url = f"{base_url}?program_url={encoded_program}&sync_url={encoded_sync}"

--- a/web-client/app/api/data/route.ts
+++ b/web-client/app/api/data/route.ts
@@ -1,5 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server";
+import { corsOptions, withCors } from "@/lib/cors";
 import client from "@/lib/mm-client";
+
+export async function OPTIONS() {
+	return corsOptions();
+}
 
 export async function GET(request: NextRequest) {
 	const { searchParams } = new URL(request.url);
@@ -15,11 +20,15 @@ export async function GET(request: NextRequest) {
 	const isAuthorized = !isTokenConfigured || token === configuredToken;
 
 	if (!path) {
-		return NextResponse.json({ error: "Path is required" }, { status: 400 });
+		return withCors(
+			NextResponse.json({ error: "Path is required" }, { status: 400 }),
+		);
 	}
 
 	if (!isAuthorized) {
-		return NextResponse.json({ error: "Unauthorized access" }, { status: 403 });
+		return withCors(
+			NextResponse.json({ error: "Unauthorized access" }, { status: 403 }),
+		);
 	}
 
 	try {
@@ -28,17 +37,21 @@ export async function GET(request: NextRequest) {
 			token: token || "",
 		});
 
-		return new NextResponse(response.content, {
-			headers: {
-				"Content-Type": response.mimeType,
-				"Cache-Control": "public, max-age=3600",
-			},
-		});
+		return withCors(
+			new NextResponse(response.content, {
+				headers: {
+					"Content-Type": response.mimeType,
+					"Cache-Control": "public, max-age=3600",
+				},
+			}),
+		);
 	} catch (error: any) {
 		console.error(`API Error (data?path=${path}):`, error);
-		return NextResponse.json(
-			{ error: `Failed to fetch file: ${error.message}` },
-			{ status: 500 },
+		return withCors(
+			NextResponse.json(
+				{ error: `Failed to fetch file: ${error.message}` },
+				{ status: 500 },
+			),
 		);
 	}
 }

--- a/web-client/app/api/submit-dq/route.ts
+++ b/web-client/app/api/submit-dq/route.ts
@@ -1,6 +1,11 @@
 import { type NextRequest, NextResponse } from "next/server";
+import { corsOptions, withCors } from "@/lib/cors";
 import { checkDqExists, saveDq } from "@/lib/dq-db";
 import client from "@/lib/mm-client";
+
+export async function OPTIONS() {
+	return corsOptions();
+}
 
 export async function POST(request: NextRequest) {
 	const { searchParams } = new URL(request.url);
@@ -14,7 +19,9 @@ export async function POST(request: NextRequest) {
 	const isAuthorized = !isTokenConfigured || token === configuredToken;
 
 	if (!isAuthorized) {
-		return NextResponse.json({ error: "Unauthorized access" }, { status: 403 });
+		return withCors(
+			NextResponse.json({ error: "Unauthorized access" }, { status: 403 }),
+		);
 	}
 
 	try {
@@ -22,9 +29,8 @@ export async function POST(request: NextRequest) {
 		const { clientDqId, event, heat, lane, swimmer, infraction_code } = payload;
 
 		if (!clientDqId) {
-			return NextResponse.json(
-				{ error: "Missing clientDqId" },
-				{ status: 400 },
+			return withCors(
+				NextResponse.json({ error: "Missing clientDqId" }, { status: 400 }),
 			);
 		}
 		if (
@@ -33,18 +39,22 @@ export async function POST(request: NextRequest) {
 			swimmer === undefined ||
 			infraction_code === undefined
 		) {
-			return NextResponse.json(
-				{ error: "Malformed payload: missing required fields" },
-				{ status: 400 },
+			return withCors(
+				NextResponse.json(
+					{ error: "Malformed payload: missing required fields" },
+					{ status: 400 },
+				),
 			);
 		}
 
 		// Idempotency check
 		const exists = await checkDqExists(clientDqId);
 		if (exists) {
-			return NextResponse.json(
-				{ success: true, message: "DQ already submitted" },
-				{ status: 200 },
+			return withCors(
+				NextResponse.json(
+					{ success: true, message: "DQ already submitted" },
+					{ status: 200 },
+				),
 			);
 		}
 
@@ -81,15 +91,16 @@ export async function POST(request: NextRequest) {
 			// We still return 200 because it's saved in Firestore and can be synced later
 		}
 
-		return NextResponse.json({
-			success: true,
-			message: "DQ submitted successfully",
-		});
+		return withCors(
+			NextResponse.json({
+				success: true,
+				message: "DQ submitted successfully",
+			}),
+		);
 	} catch (error: any) {
 		console.error("API Error (submit-dq):", error);
-		return NextResponse.json(
-			{ error: "Internal server error" },
-			{ status: 500 },
+		return withCors(
+			NextResponse.json({ error: "Internal server error" }, { status: 500 }),
 		);
 	}
 }

--- a/web-client/app/api/sync-dqs/route.ts
+++ b/web-client/app/api/sync-dqs/route.ts
@@ -1,5 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server";
+import { corsOptions, withCors } from "@/lib/cors";
 import client from "@/lib/mm-client";
+
+export async function OPTIONS() {
+	return corsOptions();
+}
 
 export async function POST(request: NextRequest) {
 	const { searchParams } = new URL(request.url);
@@ -13,7 +18,9 @@ export async function POST(request: NextRequest) {
 	const isAuthorized = !isTokenConfigured || token === configuredToken;
 
 	if (!isAuthorized) {
-		return NextResponse.json({ error: "Unauthorized access" }, { status: 403 });
+		return withCors(
+			NextResponse.json({ error: "Unauthorized access" }, { status: 403 }),
+		);
 	}
 
 	try {
@@ -27,17 +34,23 @@ export async function POST(request: NextRequest) {
 		});
 
 		if (response.success) {
-			return NextResponse.json({ success: true, message: response.message });
+			return withCors(
+				NextResponse.json({ success: true, message: response.message }),
+			);
 		}
-		return NextResponse.json(
-			{ success: false, message: response.message },
-			{ status: 500 },
+		return withCors(
+			NextResponse.json(
+				{ success: false, message: response.message },
+				{ status: 500 },
+			),
 		);
 	} catch (error: any) {
 		console.error("API Error (sync-dqs):", error);
-		return NextResponse.json(
-			{ success: false, message: error.message },
-			{ status: 500 },
+		return withCors(
+			NextResponse.json(
+				{ success: false, message: error.message },
+				{ status: 500 },
+			),
 		);
 	}
 }

--- a/web-client/lib/cors.ts
+++ b/web-client/lib/cors.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+
+export function withCors(response: NextResponse) {
+	response.headers.set("Access-Control-Allow-Origin", "*");
+	response.headers.set(
+		"Access-Control-Allow-Methods",
+		"GET, POST, PUT, DELETE, OPTIONS",
+	);
+	response.headers.set(
+		"Access-Control-Allow-Headers",
+		"Content-Type, Authorization, x-user-id",
+	);
+	return response;
+}
+
+export function corsOptions() {
+	return withCors(
+		new NextResponse(null, {
+			status: 204,
+		}),
+	);
+}


### PR DESCRIPTION
This PR addresses the "Failed to fetch" error in the Judge App and resolves URL double-encoding issues.

### **Fixes:**
1.  **CORS Headers Added**: Implemented a `withCors` helper and applied it to all stateless API routes (`/api/data`, `/api/sync-dqs`, `/api/submit-dq`). This enables the Judge App (hosted on GitHub Pages) to successfully make cross-origin requests to the Cloud Run API.
2.  **Resolved Double-Encoding**: Refined the `urllib.parse.quote` logic in the backend `PublishMeetData` method. It now uses a safer character set (`safe="/:?=&"`) for nested URLs, ensuring that already-encoded components (like the program path) are not percent-encoded a second time.
3.  **OPTIONS Handlers**: Added `OPTIONS` method support to the API routes to handle browser preflight requests.

Verified locally: API tests pass and URL generation logic confirmed.

Fixes #290
Fixes #296