### PR TITLE
fix: resolve DQ history persistence and web UI fetch failure (#321)

### DIFF
--- a/mobile-judge-app/App.tsx
+++ b/mobile-judge-app/App.tsx
@@ -143,6 +143,7 @@ export default function App() {
 	const [dqNote, setDqNote] = useState("");
 	const [pendingDqCode, setPendingDqCode] = useState<string[]>([]); // Issue #84: Multi-select
 	const [pendingCount, setPendingCount] = useState(0);
+	const [allDQs, setAllDQs] = useState<DQ[]>([]);
 	const [isLoading, setIsLoading] = useState(true);
 	const [dqCodes, setDqCodes] = useState<{ [key: string]: DqCode[] }>(
 		defaultDqCodes,
@@ -166,7 +167,13 @@ export default function App() {
 	const updatePendingCount = useCallback(() => {
 		const pending = getPendingDQs();
 		setPendingCount(pending.length);
+		setAllDQs(getAllDQs());
 	}, []);
+
+	const handleSyncComplete = useCallback(() => {
+		updatePendingCount();
+		refreshEvents();
+	}, [updatePendingCount, refreshEvents]);
 
 	useEffect(() => {
 		const initializeApp = async () => {
@@ -183,7 +190,7 @@ export default function App() {
 			}
 
 			// Initialize sync listener
-			initSyncService(updatePendingCount);
+			initSyncService(handleSyncComplete);
 
 			if (!loaded) {
 				// If error message exists, it means we TRIED to load but failed
@@ -201,7 +208,7 @@ export default function App() {
 		};
 
 		initializeApp();
-	}, [refreshEvents, updatePendingCount]);
+	}, [refreshEvents, updatePendingCount, handleSyncComplete]);
 
 	const selectEvent = (event: Event) => {
 		setSelectedEvent(event);
@@ -990,7 +997,7 @@ export default function App() {
 						<View style={styles.modalHeader}>
 							<View style={{ flexDirection: "row", alignItems: "center" }}>
 								<Text style={styles.modalTitle}>
-									DQ History (Total: {getAllDQs().length})
+									DQ History (Total: {allDQs.length})
 								</Text>
 								{pendingCount > 0 && (
 									<TouchableOpacity
@@ -1022,10 +1029,10 @@ export default function App() {
 							</TouchableOpacity>
 						</View>
 						<ScrollView style={{ padding: 15 }}>
-							{getAllDQs().length === 0 ? (
+							{allDQs.length === 0 ? (
 								<Text style={styles.emptyText}>No DQs recorded</Text>
 							) : (
-								getAllDQs().map((dq) => {
+								allDQs.map((dq) => {
 									const swimmer = getSwimmerById(dq.swimmer_id);
 									const isSynced = dq.sync_status === "synced";
 									

--- a/mobile-judge-app/src/database/db.native.ts
+++ b/mobile-judge-app/src/database/db.native.ts
@@ -67,7 +67,7 @@ export const initDatabase = () => {
 export const resetDatabase = () => {
 	if (Platform.OS === "web") return;
 	const db = getDb();
-	db.execSync("DELETE FROM dqs");
+	// dqs table is preserved to maintain history across program reloads
 	db.execSync("DELETE FROM swimmers");
 	db.execSync("DELETE FROM heats");
 	db.execSync("DELETE FROM events");

--- a/mobile-judge-app/src/database/db.web.ts
+++ b/mobile-judge-app/src/database/db.web.ts
@@ -30,7 +30,7 @@ export const resetDatabase = () => {
 	mockEvents = [];
 	mockHeats = [];
 	mockSwimmers = [];
-	mockDQs = [];
+	// mockDQs is preserved to maintain history across program reloads
 };
 
 export const loadFromJSON = (programData: {


### PR DESCRIPTION
This PR addresses the issues with DQ history persistence in the Judge App and the fetch failure in the Web UI dashboard.

### **Fixes:**
1.  **Firestore Error**: The "failed to fetch disqualifications" error was caused by the Firestore API being disabled in the GCP project. I have enabled the API and initialized the default database in `us-west1` via `gcloud`.
2.  **Judge App Persistence**: Fixed an issue where `resetDatabase()` was deleting all local DQs whenever a new meet program was loaded. Local history is now preserved across refreshes.
3.  **Reactive History UI**: Added a dedicated `allDQs` state to `App.tsx` and ensured it refreshes after each successful synchronization. This ensures the history modal correctly reflects the status of synced disqualifications.

Verified locally:
- Mobile tests pass (10/10).
- Web tests pass (46/46).

Fixes #321