### PR TITLE
fix: restore event header layout, font, and spacing (#322)

### DIFF
--- a/backend/src/mm_to_json/reporting/templates/meet_program.j2
+++ b/backend/src/mm_to_json/reporting/templates/meet_program.j2
@@ -14,8 +14,8 @@
                 <div class="entries-header-row">
                     {% if group.heats and group.heats[0].sub_items and group.heats[0].sub_items[0].is_relay %}
                         <div class="div-col col-lane">Lane</div>
-                        <div class="div-col col-spacer-name">Name</div>
-                        <div class="div-col col-spacer-age">Age</div>
+                        <div class="div-col col-spacer-name"></div>
+                        <div class="div-col col-spacer-age"></div>
                         <div class="div-col col-team">Team</div>
                         <div class="div-col col-relay">Relay</div>
                         <div class="div-col col-time">Seed Time</div>

--- a/backend/src/mm_to_json/reporting/templates/report_style.css
+++ b/backend/src/mm_to_json/reporting/templates/report_style.css
@@ -88,6 +88,18 @@ body {
     break-inside: avoid;
 }
 
+.entries-header-row {
+    display: flex;
+    font-size: 7pt;
+    color: #666;
+    text-transform: uppercase;
+    border-bottom: 0.5pt solid #eee;
+    padding: 2pt 0;
+    font-weight: bold;
+    margin-top: 2pt;
+    break-after: avoid;
+}
+
 .heat-header-row {
     font-weight: bold;
     font-size: 8.5pt;


### PR DESCRIPTION
This PR fixes the event header layout, font, and spacing in the PDF reports reported in #322.

### **Changes:**
1.  **Restored CSS**: Re-added the `.entries-header-row` style which was missing. It now uses a smaller (7pt), gray (#666), uppercase font with a light bottom border, matching professional meet program standards.
2.  **Relay Header Labels**: Updated `meet_program.j2` to remove "Name" and "Age" labels from relay headers. These labels were previously floating over empty spaces because relay rows don't show individual names/ages in the entry row.
3.  **Spacing**: Ensured consistent vertical spacing between the event header box and the column labels.

Verified locally with both individual and relay events using a reproduction script.

Fixes #322