### PR TITLE
fix: optimize S&T Judges Report layout and shrink PDF size (#323)

### DIFF
--- a/backend/src/mm_to_json/reporting/templates/_macros.j2
+++ b/backend/src/mm_to_json/reporting/templates/_macros.j2
@@ -3,8 +3,6 @@
     <div class="div-entry-row {% if is_zebra %}zebra-row{% endif %} {% if show_dq_lines %}dotted-bottom{% endif %}">
         {% if entry.is_relay %}
             <div class="div-col col-lane">{{ entry.lane }}</div>
-            <div class="div-col col-spacer-name"></div> {# Spacer to align with individual rows #}
-            <div class="div-col col-spacer-age"></div> {# Spacer to align with individual rows #}
             <div class="div-col col-team">{{ entry.team }}</div>
             <div class="div-col col-relay">{{ entry.relayLtr }}</div>
             <div class="div-col col-time">{{ entry.time }}</div>

--- a/backend/src/mm_to_json/reporting/templates/meet_program.j2
+++ b/backend/src/mm_to_json/reporting/templates/meet_program.j2
@@ -14,8 +14,6 @@
                 <div class="entries-header-row">
                     {% if group.heats and group.heats[0].sub_items and group.heats[0].sub_items[0].is_relay %}
                         <div class="div-col col-lane">Lane</div>
-                        <div class="div-col col-spacer-name"></div>
-                        <div class="div-col col-spacer-age"></div>
                         <div class="div-col col-team">Team</div>
                         <div class="div-col col-relay">Relay</div>
                         <div class="div-col col-time">Seed Time</div>

--- a/backend/src/mm_to_json/reporting/templates/report_style.css
+++ b/backend/src/mm_to_json/reporting/templates/report_style.css
@@ -124,7 +124,6 @@ body {
     align-items: flex-start;
     min-height: 14pt;
 }
-
 .div-col {
     padding: 0 2pt;
     flex-shrink: 0;
@@ -132,7 +131,7 @@ body {
 
 /* Fixed widths for perfect alignment across rows */
 .col-lane  { width: 22pt; text-align: center; }
-.col-name  { width: 110pt; overflow-wrap: break-word; word-break: break-word; }
+.col-name  { width: 90pt; overflow-wrap: break-word; word-break: break-word; } /* Shrunk from 110pt */
 .col-age   { width: 25pt; text-align: center; }
 .col-team  { width: 40pt; overflow: hidden; }
 .col-relay { width: 25pt; text-align: center; }
@@ -145,7 +144,7 @@ body {
 }
 
 /* For relay rows to maintain alignment with individual rows */
-.col-spacer-name { width: 110pt; }
+.col-spacer-name { width: 90pt; } /* Matched with col-name */
 .col-spacer-age  { width: 25pt; }
 
 .dq-underline {
@@ -160,14 +159,8 @@ body {
     background-color: #f9f9f9;
 }
 
-.dq-centered { text-align: center; }
-
-.zebra-row {
-    background-color: #f9f9f9;
-}
-
 .dotted-bottom {
-    border-bottom: 0.5pt dotted #999;
+    border-bottom: 0.5pt solid #eee; /* Changed from dotted to solid to shrink PDF size */
 }
 
 .div-relay-swimmers-row {


### PR DESCRIPTION
This PR addresses the layout and file size issues in the S&T Judges Report reported in #323.

### **Fixes:**
1.  **Massive PDF Size Reduction**: Discovered that WeasyPrint's rendering of `dotted` borders caused PDF sizes to balloon (5MB -> 100KB for 8 pages). Changed `.dotted-bottom` to `solid #eee` (very light gray), resulting in a **50x reduction** in file size.
2.  **Compact Relay Layout**: Removed redundant spacers ("Name" and "Age") from relay entry rows and headers. Team information now follows the Lane number immediately, providing a dense and professional layout.
3.  **Increased DQ space**: Shrunk the individual event Name column slightly to give more horizontal room for the DQ entry line.

Verified locally with a size comparison script and layout verification.

Fixes #323