### PR TITLE
fix: shorten 'Seed Time' to 'Seed' to prevent header wrapping (#329)

### DIFF
--- a/backend/src/mm_to_json/reporting/templates/meet_program.j2
+++ b/backend/src/mm_to_json/reporting/templates/meet_program.j2
@@ -16,14 +16,14 @@
                         <div class="div-col col-lane">Lane</div>
                         <div class="div-col col-team">Team</div>
                         <div class="div-col col-relay">Relay</div>
-                        <div class="div-col col-time">Seed Time</div>
+                        <div class="div-col col-time">Seed</div>
                         {% if show_dq_lines %}<div class="div-col col-dq dq-centered">DQ</div>{% endif %}
                     {% else %}
                         <div class="div-col col-lane">Lane</div>
                         <div class="div-col col-name">Name</div>
                         <div class="div-col col-age">Age</div>
                         <div class="div-col col-team">Team</div>
-                        <div class="div-col col-time">Seed Time</div>
+                        <div class="div-col col-time">Seed</div>
                         {% if show_dq_lines %}<div class="div-col col-dq dq-centered">DQ</div>{% endif %}
                     {% endif %}
                 </div>


### PR DESCRIPTION
This PR fixes the header wrapping issue in the primary Meet Program template reported in #329.

### **Changes:**
- Shortened the **"Seed Time"** column header label to **"Seed"**. This ensures the text fits on a single line even in high-density 2-column layouts, matching the professional look requested by the user.

Verified locally with simulated 2-column report generation.

Fixes #329