### PR TITLE
fix: constrain DQ line width for individual events to prevent overflow (#335)

### DIFF
--- a/backend/src/mm_to_json/reporting/templates/_macros.j2
+++ b/backend/src/mm_to_json/reporting/templates/_macros.j2
@@ -16,7 +16,7 @@
             <div class="div-col col-team">{{ entry.team }}</div>
             <div class="div-col col-time">{{ entry.time }}</div>
             {% if show_dq_lines %}
-                <div class="div-col col-dq"><div class="dq-underline"></div></div>
+                <div class="div-col col-dq-limited"><div class="dq-underline"></div></div>
             {% endif %}
         {% endif %}
     </div>

--- a/backend/src/mm_to_json/reporting/templates/meet_program.j2
+++ b/backend/src/mm_to_json/reporting/templates/meet_program.j2
@@ -24,7 +24,7 @@
                         <div class="div-col col-age">Age</div>
                         <div class="div-col col-team">Team</div>
                         <div class="div-col col-time">Seed</div>
-                        {% if show_dq_lines %}<div class="div-col col-dq dq-centered">DQ</div>{% endif %}
+                        {% if show_dq_lines %}<div class="div-col col-dq-limited dq-centered">DQ</div>{% endif %}
                     {% endif %}
                 </div>
 

--- a/backend/src/mm_to_json/reporting/templates/report_style.css
+++ b/backend/src/mm_to_json/reporting/templates/report_style.css
@@ -149,6 +149,12 @@ body {
     padding-left: 5pt;
 }
 
+/* Constrained width for individual event DQ lines to prevent gutter overflow */
+.col-dq-limited {
+    width: 40pt;
+    padding-left: 5pt;
+}
+
 /* For relay rows to maintain alignment with individual rows */
 .col-spacer-name { width: 90pt; } /* Matched with col-name */
 .col-spacer-age  { width: 25pt; }


### PR DESCRIPTION
This PR fixes the DQ line overflow issue in the S&T Judges Report reported in #335.

### **Fixes:**
-   **Constrained DQ Lines**: Added a new `.col-dq-limited` CSS class with a fixed width of **40pt** (shrunk by 50% from the standard 80pt).
-   **Targeted Layout**: Applied this limited width only to **individual events**. Relay events remain at their standard width as they have more horizontal space in their swimmers grid.
-   **Eliminated Overflow**: This ensure the DQ entry line stays within its column and does not bleed into the second column or the page edge in multi-column layouts.

Verified locally with simulated report generation.

Fixes #335