### PR TITLE
Add sync-meets target and .env support to Justfile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,9 @@ COMPOSE_PROJECT_NAME=meetmanager-v2
 FRONTEND_PORT=3000
 BACKEND_PORT=50051
 MOBILE_APP_PORT=8080
+
+# Season Setup Sync (Used by 'just sync-meets')
+# SOURCE: Local directory containing generated MDBs
+# DEST: Target directory (e.g., Google Drive path)
+SEASON_SETUP_SOURCE=../season-setup/2026_meets_final/2026 Del Prado Data/Swim Meets/
+SEASON_SETUP_DEST=/path/to/google/drive/2026 Del Prado Data/Swim Meets/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# play-ground
+.env
+
 .DS_Store
 *.pyc
 __pycache__/

--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,5 @@
 set shell := ["bash", "-c"]
+set dotenv-load := true
 
 # Default recipe
 default: verify
@@ -45,6 +46,16 @@ down:
     docker compose down
 
 # --- Season Setup Automation ---
+# Sync generated MDBs to a destination (e.g. Google Drive)
+# Requires SEASON_SETUP_SOURCE and SEASON_SETUP_DEST to be set in .env or environment
+sync-meets:
+    @if [ -z "$SEASON_SETUP_SOURCE" ] || [ -z "$SEASON_SETUP_DEST" ]; then \
+        echo "Error: SEASON_SETUP_SOURCE and SEASON_SETUP_DEST must be set in your .env file."; \
+        exit 1; \
+    fi
+    @echo "Syncing season MDBs..."
+    rsync -av "$SEASON_SETUP_SOURCE" "$SEASON_SETUP_DEST"
+
 generate-season TEMPLATE OUTPUT_DIR YEAR="2026" OWNER="DP":
     @echo "Generating {{YEAR}} season MDBs..."
     uv run --project MeetManager-Tools python3 backend/scripts/season_setup/generate_season.py --template {{TEMPLATE}} --output-dir {{OUTPUT_DIR}} --year {{YEAR}} --owner-team {{OWNER}}


### PR DESCRIPTION
This PR adds a new `sync-meets` target to the Justfile to automate the synchronization of generated season MDB files to Google Drive.

### Changes:
- **Justfile**: Added `sync-meets` target and enabled `dotenv-load`.
- **.env.example**: Added placeholders for sync source and destination paths.
- **.gitignore**: Added `.env` to ensure local private paths are not committed.

Closes #418