### PR TITLE
Implement automated EV3/HYV export for Team Manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           npm test
 
   build-images:
+    if: github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '[run-integration]')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -157,6 +158,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   integration-tests:
+    if: github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '[run-integration]')
     needs: build-images
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
           npm test
 
   build-images:
-    if: github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '[run-integration]')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -158,7 +157,6 @@ jobs:
           cache-to: type=gha,mode=max
 
   integration-tests:
-    if: github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '[run-integration]')
     needs: build-images
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/Justfile
+++ b/Justfile
@@ -64,6 +64,10 @@ validate-season TEMPLATE +FILES:
     @echo "Validating season setup against historical data..."
     uv run --project MeetManager-Tools python3 backend/scripts/season_setup/validate_historical.py --template {{TEMPLATE}} --historical-files {{FILES}}
 
+test-season-setup:
+    @echo "Running Season Setup logic and export tests..."
+    cd backend && PYTHONPATH=src:scripts/season_setup uv run pytest scripts/season_setup/test_season_transformer.py tests/integration/test_meet_event_export.py tests/reporting/test_meet_event_writer.py
+
 codegen-backend:
     @echo "Regenerating Backend Protos..."
     cd backend && uv run python -m grpc_tools.protoc -I../protos --python_out=src --grpc_python_out=src --pyi_out=src ../protos/meetmanager/v1/meet_manager.proto

--- a/backend/README.md
+++ b/backend/README.md
@@ -85,4 +85,10 @@ When running locally with `docker-compose` or `LocalStorageProvider`:
 
 ## API Definition
 See `protos/meetmanager/v1/meet_manager.proto` for the full Service definition.
+
+## Credits & Licensing
+The EV3 and HYV file format generation logic in `mm_to_json.reporting.meet_event_writer` was developed using the following projects as technical references for the Hy-Tek specifications:
+- **[SwimComm/hytek-parser](https://github.com/SwimComm/hytek-parser)** (MIT License)
+- **[swimstandards/swimsnap](https://github.com/swimstandards/swimsnap)** (The Unlicense)
+
 # CI Trigger

--- a/backend/scripts/season_setup/generate_season.py
+++ b/backend/scripts/season_setup/generate_season.py
@@ -1,12 +1,11 @@
-import os
-import sys
+import argparse
+import copy
 import json
 import logging
-import argparse
+import os
+import sys
 import tempfile
-import copy
 from datetime import datetime, timedelta
-import pandas as pd
 
 # Robustly add the backend/src directory to the Python path
 script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -15,9 +14,10 @@ if backend_src_dir not in sys.path:
     sys.path.append(backend_src_dir)
 sys.path.append(script_dir)
 
-from mm_to_json.mm_to_json import MmToJsonConverter
-from mm_to_json.mdb_restorer import restore_db
 from season_transformer import SeasonTransformer
+
+from mm_to_json.mdb_restorer import restore_db
+from mm_to_json.mm_to_json import MmToJsonConverter
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -25,14 +25,14 @@ logger = logging.getLogger(__name__)
 def load_config():
     config_path = os.path.join(script_dir, "config", "venues.json")
     if os.path.exists(config_path):
-        with open(config_path, "r") as f:
+        with open(config_path) as f:
             return json.load(f)
     return {"venues": {}, "teams": {}}
 
 def load_schedule(year):
     schedule_path = os.path.join(script_dir, "config", "schedule.json")
     if os.path.exists(schedule_path):
-        with open(schedule_path, "r") as f:
+        with open(schedule_path) as f:
             full_schedule = json.load(f)
             return full_schedule.get(str(year))
     return None
@@ -69,12 +69,12 @@ def generate(template_path, output_dir, year, owner_team="DP"):
 
     print(f"Loading template: {template_path}")
     template_conv = MmToJsonConverter(mdb_path=template_path)
-    
+
     # Export full schema including definitions
     full_template = template_conv.export_full_schema()
     # Normalize keys to Python strings in full_template too
     full_template["tables"] = {str(k): v for k, v in full_template["tables"].items()}
-    
+
     config = load_config()
 
     # Find the first meet date for entry open logic
@@ -93,11 +93,11 @@ def generate(template_path, output_dir, year, owner_team="DP"):
             os.makedirs(os.path.join(meet_output_dir, sub), exist_ok=True)
 
         print(f"\nGenerating MDB for: {meet['name']} ({meet['date']})")
-        
+
         # We transform the ROWS inside the full_template
         current_rows = {tname: t_def["rows"] for tname, t_def in full_template["tables"].items()}
         current_rows = copy.deepcopy(current_rows)
-        
+
         transformer = SeasonTransformer(current_rows, table_defs=full_template["tables"])
 
         # 1. Purge data
@@ -111,7 +111,7 @@ def generate(template_path, output_dir, year, owner_team="DP"):
         # Home/Away teams
         home_team = meet.get("home")
         away_team = meet.get("away")
-        
+
         if home_team:
             h_name = get_team_name(home_team, config)
             transformer.ensure_team_exists(home_team, h_name)
@@ -135,7 +135,7 @@ def generate(template_path, output_dir, year, owner_team="DP"):
                 entry_open = "2025-06-01"
         else:
             entry_open = first_meet_date
-            
+
         meet_dt = datetime.strptime(meet["date"], "%Y-%m-%d")
         deadline_dt = meet_dt - timedelta(days=4)
         entry_deadline = deadline_dt.strftime("%Y-%m-%d")
@@ -160,17 +160,17 @@ def generate(template_path, output_dir, year, owner_team="DP"):
             away_team=away_team,
             is_champs=meet["is_champs"]
         )
-        
+
         # 4. Sessions
         transformer.consolidate_sessions(is_champs=meet["is_champs"])
-        
+
         # 5. Scoring and Seeding
         transformer.setup_scoring_and_seeding(is_champs=meet["is_champs"])
         transformer.ensure_std_lanes()
 
         # Build output_data with transformed rows
         output_data = {"tables": {}}
-        
+
         # Start with all tables from the transformer (includes newly created ones)
         for tname, rows in transformer.table_data.items():
             if tname in full_template["tables"]:
@@ -201,10 +201,10 @@ def generate(template_path, output_dir, year, owner_team="DP"):
         # Restore to MDB
         filename = f"{meet['date']} {meet['name']}.mdb"
         target_mdb = os.path.join(meet_output_dir, filename)
-        
+
         print(f"Restoring to {target_mdb}...")
         restore_db(temp_json, target_mdb)
-        
+
         # Cleanup
         os.remove(temp_json)
 

--- a/backend/scripts/season_setup/generate_season.py
+++ b/backend/scripts/season_setup/generate_season.py
@@ -6,7 +6,6 @@ import argparse
 import tempfile
 import copy
 from datetime import datetime, timedelta
-import pandas as pd
 
 # Robustly add the backend/src directory to the Python path
 script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -15,12 +14,15 @@ if backend_src_dir not in sys.path:
     sys.path.append(backend_src_dir)
 sys.path.append(script_dir)
 
-from mm_to_json.mm_to_json import MmToJsonConverter
-from mm_to_json.mdb_restorer import restore_db
-from season_transformer import SeasonTransformer
+from season_transformer import SeasonTransformer  # noqa: E402
+
+from mm_to_json.mdb_restorer import restore_db  # noqa: E402
+from mm_to_json.mm_to_json import MmToJsonConverter  # noqa: E402
+from mm_to_json.reporting.meet_event_writer import MeetEventWriter  # noqa: E402
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
 
 def load_config():
     config_path = os.path.join(script_dir, "config", "venues.json")
@@ -28,6 +30,7 @@ def load_config():
         with open(config_path, "r") as f:
             return json.load(f)
     return {"venues": {}, "teams": {}}
+
 
 def load_schedule(year):
     schedule_path = os.path.join(script_dir, "config", "schedule.json")
@@ -37,24 +40,28 @@ def load_schedule(year):
             return full_schedule.get(str(year))
     return None
 
+
 def get_venue_info(host, config):
     info = config.get("venues", {}).get(host, {"lanes": 6, "address": ""})
     return info
 
+
 def get_team_name(abbr, config):
     return config.get("teams", {}).get(abbr, abbr)
+
 
 def to_python(obj):
     """Recursively convert Java/Pandas objects to standard Python types."""
     if "java.lang.String" in str(type(obj)):
         return str(obj)
-    if hasattr(obj, 'isoformat'):
+    if hasattr(obj, "isoformat"):
         return obj.isoformat()
     if isinstance(obj, dict):
         return {to_python(k): to_python(v) for k, v in obj.items()}
     if isinstance(obj, (list, tuple)):
         return [to_python(x) for x in obj]
     return obj
+
 
 def generate(template_path, output_dir, year, owner_team="DP"):
     schedule = load_schedule(year)
@@ -69,12 +76,12 @@ def generate(template_path, output_dir, year, owner_team="DP"):
 
     print(f"Loading template: {template_path}")
     template_conv = MmToJsonConverter(mdb_path=template_path)
-    
+
     # Export full schema including definitions
     full_template = template_conv.export_full_schema()
     # Normalize keys to Python strings in full_template too
     full_template["tables"] = {str(k): v for k, v in full_template["tables"].items()}
-    
+
     config = load_config()
 
     # Find the first meet date for entry open logic
@@ -93,11 +100,11 @@ def generate(template_path, output_dir, year, owner_team="DP"):
             os.makedirs(os.path.join(meet_output_dir, sub), exist_ok=True)
 
         print(f"\nGenerating MDB for: {meet['name']} ({meet['date']})")
-        
+
         # We transform the ROWS inside the full_template
         current_rows = {tname: t_def["rows"] for tname, t_def in full_template["tables"].items()}
         current_rows = copy.deepcopy(current_rows)
-        
+
         transformer = SeasonTransformer(current_rows, table_defs=full_template["tables"])
 
         # 1. Purge data
@@ -111,7 +118,7 @@ def generate(template_path, output_dir, year, owner_team="DP"):
         # Home/Away teams
         home_team = meet.get("home")
         away_team = meet.get("away")
-        
+
         if home_team:
             h_name = get_team_name(home_team, config)
             transformer.ensure_team_exists(home_team, h_name)
@@ -131,11 +138,11 @@ def generate(template_path, output_dir, year, owner_team="DP"):
             try:
                 dt = datetime.strptime(meet["date"], "%Y-%m-%d")
                 entry_open = f"{dt.year - 1}-06-01"
-            except:
+            except Exception:
                 entry_open = "2025-06-01"
         else:
             entry_open = first_meet_date
-            
+
         meet_dt = datetime.strptime(meet["date"], "%Y-%m-%d")
         deadline_dt = meet_dt - timedelta(days=4)
         entry_deadline = deadline_dt.strftime("%Y-%m-%d")
@@ -158,19 +165,19 @@ def generate(template_path, output_dir, year, owner_team="DP"):
             owner_team=owner_team,
             home_team=home_team,
             away_team=away_team,
-            is_champs=meet["is_champs"]
+            is_champs=meet["is_champs"],
         )
-        
+
         # 4. Sessions
         transformer.consolidate_sessions(is_champs=meet["is_champs"])
-        
+
         # 5. Scoring and Seeding
         transformer.setup_scoring_and_seeding(is_champs=meet["is_champs"])
         transformer.ensure_std_lanes()
 
         # Build output_data with transformed rows
         output_data = {"tables": {}}
-        
+
         # Start with all tables from the transformer (includes newly created ones)
         for tname, rows in transformer.table_data.items():
             if tname in full_template["tables"]:
@@ -184,38 +191,46 @@ def generate(template_path, output_dir, year, owner_team="DP"):
                 if rows:
                     for k in rows[0].keys():
                         cols.append({"name": k, "type": "TEXT"})
-                output_data["tables"][tname] = {
-                    "columns": cols,
-                    "indexes": [],
-                    "rows": rows
-                }
+                output_data["tables"][tname] = {"columns": cols, "indexes": [], "rows": rows}
 
         # Convert entire structure to Python types for JSON
         output_data = to_python(output_data)
 
         # Write to temp JSON
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tf:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tf:
             json.dump(output_data, tf)
             temp_json = tf.name
 
         # Restore to MDB
         filename = f"{meet['date']} {meet['name']}.mdb"
         target_mdb = os.path.join(meet_output_dir, filename)
-        
+
         print(f"Restoring to {target_mdb}...")
         restore_db(temp_json, target_mdb)
-        
+
+        # 6. Export to Team Manager (ZIP with EV3/HYV)
+        # Find required tables logically
+        meet_keys = transformer._get_all_table_keys("meet")
+        event_keys = transformer._get_all_table_keys("event")
+        session_keys = transformer._get_all_table_keys("session")
+        scoring_keys = transformer._get_all_table_keys("scoring")
+
+        if meet_keys and event_keys:
+            meet_info = transformer.table_data[meet_keys[0]][0]
+            events = transformer.table_data[event_keys[0]]
+            sessions = transformer.table_data[session_keys[0]] if session_keys else []
+            scoring = transformer.table_data[scoring_keys[0]] if scoring_keys else []
+
+            # Format filename as MM/DD/YYYY -> MMDDYYYY
+            m_date = datetime.strptime(meet["date"], "%Y-%m-%d").strftime("%d%b%Y")
+            zip_filename = f"Meet Events-{meet['name']}-{m_date}-001.zip"
+            target_zip = os.path.join(meet_output_dir, zip_filename)
+
+            writer = MeetEventWriter(meet_info, sessions, events, scoring)
+            writer.write_to_zip(target_zip)
+            print(f"Exported Team Manager events to {target_zip}")
+
         # Cleanup
         os.remove(temp_json)
 
     print(f"\nDone! All meets generated in {season_data_dir}")
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--template", required=True, help="Path to blank template MDB")
-    parser.add_argument("--output-dir", required=True, help="Directory to save generated MDBs")
-    parser.add_argument("--year", type=int, default=2026, help="The season year (default: 2026)")
-    parser.add_argument("--owner-team", default="DP", help="The abbreviation of the host team to preserve in the MDB (default: DP)")
-    args = parser.parse_args()
-
-    generate(args.template, args.output_dir, args.year, args.owner_team)

--- a/backend/scripts/season_setup/generate_season.py
+++ b/backend/scripts/season_setup/generate_season.py
@@ -1,10 +1,10 @@
-import argparse
-import copy
-import json
-import logging
 import os
 import sys
+import json
+import logging
+import argparse
 import tempfile
+import copy
 from datetime import datetime, timedelta
 
 # Robustly add the backend/src directory to the Python path
@@ -144,7 +144,7 @@ def generate(template_path, output_dir, year, owner_team="DP"):
             entry_open = first_meet_date
 
         meet_dt = datetime.strptime(meet["date"], "%Y-%m-%d")
-        deadline_dt = meet_dt - timedelta(days=4)
+        deadline_dt = meet_dt - timedelta(days=2)
         entry_deadline = deadline_dt.strftime("%Y-%m-%d")
 
         # Age up is usually 6/1 of current year
@@ -234,3 +234,18 @@ def generate(template_path, output_dir, year, owner_team="DP"):
         os.remove(temp_json)
 
     print(f"\nDone! All meets generated in {season_data_dir}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--template", required=True, help="Path to blank template MDB")
+    parser.add_argument("--output-dir", required=True, help="Directory to save generated MDBs")
+    parser.add_argument("--year", type=int, default=2026, help="The season year (default: 2026)")
+    parser.add_argument(
+        "--owner-team",
+        default="DP",
+        help="The abbreviation of the host team to preserve in the MDB (default: DP)",
+    )
+    args = parser.parse_args()
+
+    generate(args.template, args.output_dir, args.year, args.owner_team)

--- a/backend/scripts/season_setup/generate_season.py
+++ b/backend/scripts/season_setup/generate_season.py
@@ -202,7 +202,7 @@ def generate(template_path, output_dir, year, owner_team="DP"):
             temp_json = tf.name
 
         # Restore to MDB
-        filename = f"{meet['date']} {meet['name']}.mdb"
+        filename = f"{meet['date']} {meet['name']}-audit-v4.mdb"
         target_mdb = os.path.join(meet_output_dir, filename)
 
         print(f"Restoring to {target_mdb}...")

--- a/backend/scripts/season_setup/generate_season.py
+++ b/backend/scripts/season_setup/generate_season.py
@@ -1,10 +1,10 @@
-import os
-import sys
+import argparse
+import copy
 import json
 import logging
-import argparse
+import os
+import sys
 import tempfile
-import copy
 from datetime import datetime, timedelta
 
 # Robustly add the backend/src directory to the Python path
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 def load_config():
     config_path = os.path.join(script_dir, "config", "venues.json")
     if os.path.exists(config_path):
-        with open(config_path, "r") as f:
+        with open(config_path) as f:
             return json.load(f)
     return {"venues": {}, "teams": {}}
 
@@ -35,7 +35,7 @@ def load_config():
 def load_schedule(year):
     schedule_path = os.path.join(script_dir, "config", "schedule.json")
     if os.path.exists(schedule_path):
-        with open(schedule_path, "r") as f:
+        with open(schedule_path) as f:
             full_schedule = json.load(f)
             return full_schedule.get(str(year))
     return None

--- a/backend/scripts/season_setup/season_transformer.py
+++ b/backend/scripts/season_setup/season_transformer.py
@@ -267,15 +267,16 @@ class SeasonTransformer:
                         7: 12.0, 8: 11.0, 9: 9.0, 10: 7.0, 11: 6.0, 12: 5.0,
                         13: 4.0, 14: 3.0, 15: 2.0, 16: 1.0
                     }
-                    # Relays (5 places): 40-34-32-30-28
+                    # Relays (8 places): 40-34-32-30-28-26-24-22
                     rel_points = {
-                        1: 40.0, 2: 34.0, 3: 32.0, 4: 30.0, 5: 28.0
+                        1: 40.0, 2: 34.0, 3: 32.0, 4: 30.0, 5: 28.0,
+                        6: 26.0, 7: 24.0, 8: 22.0
                     }
                 else:
                     # Dual meet standard: 5-3-2-1 for individual, 10-6 for relays
                     ind_points = {1: 5.0, 2: 3.0, 3: 2.0, 4: 1.0}
-                    # Relays are usually 2x individual
-                    rel_points = {k: v * 2 for k, v in ind_points.items()}
+                    # Relays: 10, 6
+                    rel_points = {1: 10.0, 2: 6.0}
                 
                 for row in scoring:
                     actual_cols = {k.lower(): k for k in row.keys()}

--- a/backend/scripts/season_setup/season_transformer.py
+++ b/backend/scripts/season_setup/season_transformer.py
@@ -1,14 +1,13 @@
+import json
 import logging
 import os
-import json
-import copy
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 class SeasonTransformer:
-    def __init__(self, table_data: Dict[str, List[Dict[str, Any]]], table_defs: Optional[Dict[str, Any]] = None):
+    def __init__(self, table_data: dict[str, list[dict[str, Any]]], table_defs: dict[str, Any] | None = None):
         """
         Initializes the SeasonTransformer with table data and optional definitions.
         table_data is a dictionary where keys are table names and values are lists of dictionaries (records).
@@ -17,7 +16,7 @@ class SeasonTransformer:
         self.table_data = {str(k): v for k, v in table_data.items()}
         self.table_defs = {str(k): v for k, v in table_defs.items()} if table_defs else {}
         self.team_ids = {} # Track team abbr -> ID
-        
+
         # Standard table aliases to match MmToJsonConverter logic
         self.table_aliases = {
             "meet": ["Meet", "MEET", "meet"],
@@ -34,23 +33,23 @@ class SeasonTransformer:
             "stdlanes": ["StdLanes", "STDLANES", "stdlanes"],
         }
 
-    def _get_all_table_keys(self, logical_name: str) -> List[str]:
+    def _get_all_table_keys(self, logical_name: str) -> list[str]:
         """Finds all actual keys in table_data that match a logical table name (case-insensitive)."""
         candidates = set(c.lower() for c in self.table_aliases.get(logical_name, [logical_name]))
         found_keys = []
         for actual_key in self.table_data.keys():
             if str(actual_key).lower() in candidates:
                 found_keys.append(actual_key)
-        
+
         # Fallback: if no aliases match, check if logical_name itself matches case-insensitively
         if not found_keys:
             for actual_key in self.table_data.keys():
                 if str(actual_key).lower() == logical_name.lower():
                     found_keys.append(actual_key)
-                    
+
         return found_keys
 
-    def _set_table(self, logical_name: str, records: List[Dict[str, Any]]):
+    def _set_table(self, logical_name: str, records: list[dict[str, Any]]):
         """Updates the records for a logical table name while preserving existing casing."""
         keys = self._get_all_table_keys(logical_name)
         if keys:
@@ -67,7 +66,7 @@ class SeasonTransformer:
         Filters TEAM table to keep only standard teams from venues.json or the preserved team.
         """
         logger.info(f"Purging data (preserving team: {preserve_team_abbr})")
-        
+
         # transaction tables
         for logical in ["athlete", "entry", "relay", "relaynames"]:
             for key in self._get_all_table_keys(logical):
@@ -78,7 +77,7 @@ class SeasonTransformer:
             config_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config")
             venues_path = os.path.join(config_dir, "venues.json")
             if os.path.exists(venues_path):
-                with open(venues_path, "r") as f:
+                with open(venues_path) as f:
                     config = json.load(f)
                     for t in config.get("teams", {}).keys():
                         standard_teams.add(t.upper())
@@ -89,7 +88,7 @@ class SeasonTransformer:
             teams = self.table_data[key]
             # Standard candidates for team abbreviation
             abbr_cols = ["tcode", "team_abbr", "abbr"]
-            
+
             filtered_teams = []
             for t in teams:
                 # Find the actual value for abbreviation in this record
@@ -101,14 +100,14 @@ class SeasonTransformer:
                         t_abbr = str(v).strip().upper()
                     if lk in ["team", "team_no", "team_ptr"]:
                         t_id = v
-                
+
                 if t_abbr and t_abbr in standard_teams:
                     filtered_teams.append(t)
                     self.team_ids[t_abbr] = t_id
-            
+
             self.table_data[key] = filtered_teams
 
-    def _date_to_ms(self, date_str: str) -> Optional[int]:
+    def _date_to_ms(self, date_str: str) -> int | None:
         """Converts a date string (YYYY-MM-DD) to milliseconds since epoch."""
         if not date_str:
             return None
@@ -116,7 +115,7 @@ class SeasonTransformer:
             # Handle already numeric or other formats if needed
             if isinstance(date_str, (int, float)):
                 return int(date_str)
-            
+
             # Try to parse YYYY-MM-DD
             dt = datetime.strptime(date_str, "%Y-%m-%d")
             return int(dt.timestamp() * 1000)
@@ -133,16 +132,16 @@ class SeasonTransformer:
                 # Update all common lane columns
                 lane_cols = ["Num_prelanes", "Num_finlanes", "Num_semlanes", "Num_LanesInBestHeatsTimedFinal"]
                 actual_cols = {k.lower(): k for k in event.keys()}
-                
+
                 for col in lane_cols:
                     if col.lower() in actual_cols:
                         event[actual_cols[col.lower()]] = lanes
-                
+
                 # Also set Std_lanes to 'A' (Automatic) to ensure seeding rules apply
                 if "std_lanes" in actual_cols:
                     event[actual_cols["std_lanes"]] = "A"
 
-    def update_meet(self, name: str, start_date: str, lanes: int, location: str = "", address: str = "", city: str = "", state: str = "", zip_code: str = "", age_up: str = "2026-06-01", entry_open: str = "", entry_deadline: str = "", owner_team: str = "DP", home_team: Optional[str] = None, away_team: Optional[str] = None, is_champs: bool = False):
+    def update_meet(self, name: str, start_date: str, lanes: int, location: str = "", address: str = "", city: str = "", state: str = "", zip_code: str = "", age_up: str = "2026-06-01", entry_open: str = "", entry_deadline: str = "", owner_team: str = "DP", home_team: str | None = None, away_team: str | None = None, is_champs: bool = False):
         """Updates the MEET table metadata across all possible aliases."""
         # First, update all events to match pool lanes
         self.update_event_lanes(lanes)
@@ -156,7 +155,7 @@ class SeasonTransformer:
             meet_table = self.table_data[key]
             if not meet_table:
                 meet_table = [{}]
-            
+
             mappings = {
                 "name": ["meet_name1", "MEET_NAME1", "Meet_name1", "meet"],
                 "start": ["meet_start", "MEET_START", "Meet_start", "start"],
@@ -189,13 +188,13 @@ class SeasonTransformer:
             away_id = self.team_ids.get(away_team.upper(), 0) if away_team else 0
 
             values = {
-                "name": name, 
-                "start": self._date_to_ms(start_date), 
-                "end": self._date_to_ms(start_date), 
+                "name": name,
+                "start": self._date_to_ms(start_date),
+                "end": self._date_to_ms(start_date),
                 "lanes": lanes,
-                "age_up": self._date_to_ms(age_up), 
-                "location": location, 
-                "open": self._date_to_ms(entry_open), 
+                "age_up": self._date_to_ms(age_up),
+                "location": location,
+                "open": self._date_to_ms(entry_open),
                 "deadline": self._date_to_ms(entry_deadline),
                 "idformat": 1, # USAS
                 "hostlsc": "CC",
@@ -267,19 +266,20 @@ class SeasonTransformer:
                         7: 12.0, 8: 11.0, 9: 9.0, 10: 7.0, 11: 6.0, 12: 5.0,
                         13: 4.0, 14: 3.0, 15: 2.0, 16: 1.0
                     }
-                    # Relays (5 places): 40-34-32-30-28
+                    # Relays (8 places): 40-34-32-30-28-26-24-22
                     rel_points = {
-                        1: 40.0, 2: 34.0, 3: 32.0, 4: 30.0, 5: 28.0
+                        1: 40.0, 2: 34.0, 3: 32.0, 4: 30.0, 5: 28.0,
+                        6: 26.0, 7: 24.0, 8: 22.0
                     }
                 else:
                     # Dual meet standard: 5-3-2-1 for individual, 10-6 for relays
                     ind_points = {1: 5.0, 2: 3.0, 3: 2.0, 4: 1.0}
-                    # Relays are usually 2x individual
-                    rel_points = {k: v * 2 for k, v in ind_points.items()}
-                
+                    # Relays: 10, 6
+                    rel_points = {1: 10.0, 2: 6.0}
+
                 for row in scoring:
                     actual_cols = {k.lower(): k for k in row.keys()}
-                    
+
                     if "score_place" in actual_cols:
                         place = row[actual_cols["score_place"]]
                         if "ind_score" in actual_cols:
@@ -293,7 +293,7 @@ class SeasonTransformer:
                             target = f"ind{i}"
                             if target in actual_cols:
                                 row[actual_cols[target]] = val
-                        
+
                         rel_list = [rel_points.get(i, 0.0) for i in range(1, 17)]
                         for i, val in enumerate(rel_list, 1):
                             target = f"rel{i}"
@@ -400,7 +400,7 @@ class SeasonTransformer:
         new_sessitems = []
         events = self.table_data[event_keys[0]] if event_keys else []
         logger.info(f"Distributing {len(events)} events into {len(champs_sessions)} sessions")
-        
+
         for i, s_def in enumerate(champs_sessions, 1):
             sess_ptr = i
             session_records.append({
@@ -417,13 +417,13 @@ class SeasonTransformer:
                 actual_cols = {k.lower(): k for k in event.keys()}
                 e_stroke = str(event.get(actual_cols.get("event_stroke"), "")).strip().upper()
                 e_indrel = str(event.get(actual_cols.get("ind_rel"), "")).strip().upper()
-                
+
                 if e_stroke == s_def["stroke"] and e_indrel == s_def["ind_rel"]:
                     sess_events.append(event)
                     # Link event to session if column exists
                     if "session" in actual_cols:
                         event[actual_cols["session"]] = sess_ptr
-            
+
             # Sort by event_no to preserve order
             def get_event_no(x):
                 ac = {k.lower(): k for k in x.keys()}
@@ -440,7 +440,7 @@ class SeasonTransformer:
                     e_ptr = event[actual_cols["event_ptr"]]
                 elif "mtevent" in actual_cols:
                     e_ptr = event[actual_cols["mtevent"]]
-                
+
                 new_sessitems.append({
                     "Sess_order": j, "Sess_ptr": sess_ptr, "Event_ptr": e_ptr,
                     "Sess_rnd": "F", "Rept_type": "H", "Delay_seconds": 0, "Alt_With": False
@@ -471,16 +471,16 @@ class SeasonTransformer:
                         found_abbr = str(v).strip().upper()
                     if lk in ["team", "team_no", "team_ptr"]:
                         found_id = v
-                
+
                 if found_abbr == str(abbr).strip().upper():
                     existing_id = found_id
                     break
-            
+
             if existing_id is not None:
                 self.team_ids[abbr.upper()] = existing_id
             else:
                 logger.info(f"Adding missing team: {abbr} ({name}) to {key}")
-                
+
                 matched_team = {}
                 max_no = 0
                 for t in teams:
@@ -488,14 +488,14 @@ class SeasonTransformer:
                         if str(k).lower() in ["team", "team_no", "team_ptr"] and v:
                             try: max_no = max(max_no, int(v))
                             except: pass
-                
+
                 new_id = max_no + 1
                 template_rec = None
-                if teams: 
+                if teams:
                     template_rec = teams[0]
                 elif key in self.table_defs:
                     template_rec = {c["name"]: None for c in self.table_defs[key].get("columns", [])}
-                
+
                 if template_rec:
                     for k, v in template_rec.items():
                         lk = k.lower()
@@ -514,6 +514,6 @@ class SeasonTransformer:
                         "LSC": "CC", "TType": "AGE", "Team_no": new_id
                     }
                     teams.append(new_team)
-                
+
                 self.team_ids[abbr.upper()] = new_id
                 self.table_data[key] = teams

--- a/backend/scripts/season_setup/test_season_transformer.py
+++ b/backend/scripts/season_setup/test_season_transformer.py
@@ -1,6 +1,7 @@
+
 import pytest
-import os
 from season_transformer import SeasonTransformer
+
 
 @pytest.fixture
 def sample_data():
@@ -26,11 +27,11 @@ def sample_data():
 def test_purge_data(sample_data):
     transformer = SeasonTransformer(sample_data)
     transformer.purge_data(preserve_team_abbr="DP")
-    
+
     assert len(transformer.table_data["ATHLETE"]) == 0
     assert len(transformer.table_data["ENTRY"]) == 0
     assert len(transformer.table_data["RELAY"]) == 0
-    
+
     team_codes = [t.get("TCode") or t.get("tcode") for t in transformer.table_data["TEAM"]]
     assert "DP" in team_codes
     assert "OLD" not in team_codes
@@ -38,41 +39,59 @@ def test_purge_data(sample_data):
 def test_update_meet(sample_data):
     transformer = SeasonTransformer(sample_data)
     transformer.update_meet("New Season", "2026-06-01", 8, age_up="2026-06-01")
-    
+
     meet = transformer.table_data["MEET"][0]
     # Check mappings (SeasonTransformer uses logical names but preserves casing)
     assert meet["meet_name1"] == "New Season"
     assert meet["meet_numlanes"] == 8
-    
+
     # Check that events were also updated
     for event in transformer.table_data["MTEVENT"]:
         assert event["Num_prelanes"] == 8
         assert event["Std_lanes"] == "A"
 
 def test_championship_scoring(sample_data):
-    """Ensures Champs scoring uses 16 individual places and 5 relay places."""
+    """Ensures Champs scoring uses 16 individual places and 8 relay places."""
     transformer = SeasonTransformer(sample_data)
     transformer.setup_scoring_and_seeding(is_champs=True)
-    
+
     scoring = transformer.table_data["Scoring"]
-    
+
     # Individual: 1st=20, 12th=5, 16th=1
     assert float(scoring[0]["ind_score"]) == 20.0
     assert float(scoring[11]["ind_score"]) == 5.0
     assert float(scoring[15]["ind_score"]) == 1.0
-    
-    # Relays: 1st=40, 5th=28, 6th=0
+
+    # Relays: 1st=40, 5th=28, 8th=22, 9th=0
     assert float(scoring[0]["rel_score"]) == 40.0
     assert float(scoring[4]["rel_score"]) == 28.0
-    assert float(scoring[5]["rel_score"]) == 0.0
+    assert float(scoring[7]["rel_score"]) == 22.0
+    assert float(scoring[8]["rel_score"]) == 0.0
+
+def test_dual_scoring(sample_data):
+    """Ensures Dual scoring uses 4 individual places and 2 relay places."""
+    transformer = SeasonTransformer(sample_data)
+    transformer.setup_scoring_and_seeding(is_champs=False)
+
+    scoring = transformer.table_data["Scoring"]
+
+    # Individual: 1st=5, 4th=1
+    assert float(scoring[0]["ind_score"]) == 5.0
+    assert float(scoring[3]["ind_score"]) == 1.0
+    assert float(scoring[4]["ind_score"]) == 0.0
+
+    # Relays: 1st=10, 2nd=6, 3rd=0
+    assert float(scoring[0]["rel_score"]) == 10.0
+    assert float(scoring[1]["rel_score"]) == 6.0
+    assert float(scoring[2]["rel_score"]) == 0.0
 
 def test_consolidate_sessions_dual(sample_data):
     transformer = SeasonTransformer(sample_data)
     transformer.consolidate_sessions(is_champs=False)
-    
+
     assert len(transformer.table_data["SESSIONS"]) == 1
     assert transformer.table_data["SESSIONS"][0]["Sess_no"] == 1
-    
+
     # Check event linking
     for event in transformer.table_data["MTEVENT"]:
         assert event["Session"] == 1
@@ -81,15 +100,15 @@ def test_consolidate_sessions_champs(sample_data):
     """Ensures Champs layout creates 7 sessions and links events correctly."""
     transformer = SeasonTransformer(sample_data)
     transformer.consolidate_sessions(is_champs=True)
-    
+
     assert len(transformer.table_data["SESSIONS"]) == 7
-    
+
     events = transformer.table_data["MTEVENT"]
     # Event 1: Stroke E, Ind_rel R -> Med Relays (Session 1)
     assert events[0]["Session"] == 1
     # Event 2: Stroke A, Ind_rel I -> Freestyle (Session 2)
     assert events[1]["Session"] == 2
-    
+
     # Check Sessitem
     sessitems = transformer.table_data["Sessitem"]
     assert len(sessitems) == 2
@@ -100,10 +119,10 @@ def test_ensure_std_lanes(sample_data):
     """Ensures standard seeding orders are created with correct MM column names."""
     transformer = SeasonTransformer(sample_data)
     transformer.ensure_std_lanes()
-    
+
     std_lanes = transformer.table_data["StdLanes"]
     assert len(std_lanes) == 12
-    
+
     # Check 6 lanes order: 3, 4, 2, 5, 1, 6
     row6 = next(r for r in std_lanes if r["Lanes"] == 6)
     assert row6["Order1"] == 3
@@ -112,6 +131,6 @@ def test_ensure_std_lanes(sample_data):
 def test_ensure_team_exists(sample_data):
     transformer = SeasonTransformer(sample_data)
     transformer.ensure_team_exists("CW", "Castlewood")
-    
+
     team_codes = [t.get("TCode") or t.get("tcode") for t in transformer.table_data["TEAM"]]
     assert "CW" in team_codes

--- a/backend/scripts/season_setup/test_season_transformer.py
+++ b/backend/scripts/season_setup/test_season_transformer.py
@@ -50,7 +50,7 @@ def test_update_meet(sample_data):
         assert event["Std_lanes"] == "A"
 
 def test_championship_scoring(sample_data):
-    """Ensures Champs scoring uses 16 individual places and 5 relay places."""
+    """Ensures Champs scoring uses 16 individual places and 8 relay places."""
     transformer = SeasonTransformer(sample_data)
     transformer.setup_scoring_and_seeding(is_champs=True)
     
@@ -61,10 +61,28 @@ def test_championship_scoring(sample_data):
     assert float(scoring[11]["ind_score"]) == 5.0
     assert float(scoring[15]["ind_score"]) == 1.0
     
-    # Relays: 1st=40, 5th=28, 6th=0
+    # Relays: 1st=40, 5th=28, 8th=22, 9th=0
     assert float(scoring[0]["rel_score"]) == 40.0
     assert float(scoring[4]["rel_score"]) == 28.0
-    assert float(scoring[5]["rel_score"]) == 0.0
+    assert float(scoring[7]["rel_score"]) == 22.0
+    assert float(scoring[8]["rel_score"]) == 0.0
+
+def test_dual_scoring(sample_data):
+    """Ensures Dual scoring uses 4 individual places and 2 relay places."""
+    transformer = SeasonTransformer(sample_data)
+    transformer.setup_scoring_and_seeding(is_champs=False)
+    
+    scoring = transformer.table_data["Scoring"]
+    
+    # Individual: 1st=5, 4th=1
+    assert float(scoring[0]["ind_score"]) == 5.0
+    assert float(scoring[3]["ind_score"]) == 1.0
+    assert float(scoring[4]["ind_score"]) == 0.0
+    
+    # Relays: 1st=10, 2nd=6, 3rd=0
+    assert float(scoring[0]["rel_score"]) == 10.0
+    assert float(scoring[1]["rel_score"]) == 6.0
+    assert float(scoring[2]["rel_score"]) == 0.0
 
 def test_consolidate_sessions_dual(sample_data):
     transformer = SeasonTransformer(sample_data)

--- a/backend/scripts/season_setup/tvsl_scraper.py
+++ b/backend/scripts/season_setup/tvsl_scraper.py
@@ -1,9 +1,7 @@
+import re
+
 import requests
 from bs4 import BeautifulSoup
-import json
-import os
-import re
-from datetime import datetime
 
 # TVSL Schedule URL
 TVSL_URL = "http://www.trivalleyswimleague.com/Schedule"
@@ -18,11 +16,11 @@ def fetch_schedule(year=2026):
         return None
 
     soup = BeautifulSoup(response.text, 'html.parser')
-    
+
     # TVSL website structure varies, but usually it's in a table
     # We look for rows that look like meet dates
     meets = []
-    
+
     # This is a heuristic-based scraper since I don't have the live HTML yet
     # I'll try to find common table patterns
     tables = soup.find_all('table')
@@ -34,17 +32,17 @@ def fetch_schedule(year=2026):
             date_match = re.search(r'(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d+', text)
             if not date_match:
                 date_match = re.search(r'\d{1,2}/\d{1,2}', text)
-                
+
             if date_match:
                 # Potential meet row
                 # We need to parse: Date, Name, Home, Away, Venue
                 # For now, we'll log what we find to refine the scraper
                 print(f"Found potential meet row: {text}")
-                
+
     # Since I cannot see the live site and it might be empty for 2026 until spring,
     # I will provide a placeholder that mimics the current schedule.json format
     # but with the ability to be updated once the website is live.
-    
+
     return None
 
 if __name__ == "__main__":

--- a/backend/scripts/season_setup/validate_historical.py
+++ b/backend/scripts/season_setup/validate_historical.py
@@ -1,9 +1,7 @@
+import argparse
+import logging
 import os
 import sys
-import json
-import logging
-import argparse
-from datetime import datetime
 
 # Robustly add the backend/src directory to the Python path
 script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -12,8 +10,9 @@ if backend_src_dir not in sys.path:
     sys.path.append(backend_src_dir)
 sys.path.append(script_dir)
 
-from mm_to_json.mm_to_json import MmToJsonConverter
 from season_transformer import SeasonTransformer
+
+from mm_to_json.mm_to_json import MmToJsonConverter
 
 logging.basicConfig(level=logging.INFO)
 
@@ -23,7 +22,7 @@ def validate(template_mdb, historical_mdbs, owner_team="DP"):
     template_conv = MmToJsonConverter(mdb_path=template_mdb)
     full_template = template_conv.export_full_schema()
     full_template["tables"] = {str(k): v for k, v in full_template["tables"].items()}
-    
+
     template_rows = {name: t_def["rows"] for name, t_def in full_template["tables"].items()}
 
     results = []
@@ -37,13 +36,13 @@ def validate(template_mdb, historical_mdbs, owner_team="DP"):
         # Extract historical metadata
         target_conv = MmToJsonConverter(mdb_path=mdb_path)
         target_meet = target_conv.tables.get("meet").iloc[0]
-        
+
         # Determine name, date, lanes, location
         name = target_meet.get("meet_name1")
         date = target_meet.get("meet_start")
         lanes = int(target_meet.get("meet_numlanes") or 6)
         location = target_meet.get("meet_location")
-        
+
         if hasattr(date, 'timestamp'):
             age_up = f"{date.year}-06-01"
             date_str = date.strftime("%Y-%m-%d")
@@ -57,12 +56,12 @@ def validate(template_mdb, historical_mdbs, owner_team="DP"):
         import copy
         current_data = copy.deepcopy(template_rows)
         transformer = SeasonTransformer(current_data, table_defs=full_template["tables"])
-        
+
         transformer.purge_data(preserve_team_abbr=owner_team)
         transformer.update_meet(name, date_str, lanes, location=location, age_up=age_up)
         is_champs = "CHAMPS" in str(name).upper() or "CHAMPIONSHIP" in str(name).upper()
         transformer.consolidate_sessions(is_champs=is_champs)
-        
+
         # Compare
         def get_table(data, logical):
             aliases = ["Meet", "MEET", "meet"] if logical == "meet" else ["Session", "SESSIONS", "session"]
@@ -72,7 +71,7 @@ def validate(template_mdb, historical_mdbs, owner_team="DP"):
 
         transformed_meet = get_table(transformer.table_data, "meet")
         transformed_row = transformed_meet[0]
-        
+
         mismatches = []
         # Case-insensitive check for name
         t_name = None
@@ -80,10 +79,10 @@ def validate(template_mdb, historical_mdbs, owner_team="DP"):
             if k.lower() == "meet_name1":
                 t_name = v
                 break
-        
+
         if t_name != name:
             mismatches.append(f"Name mismatch: {t_name} != {name}")
-            
+
         # Case-insensitive check for lanes
         t_lanes = None
         for k, v in transformed_row.items():
@@ -93,7 +92,7 @@ def validate(template_mdb, historical_mdbs, owner_team="DP"):
 
         if t_lanes != lanes:
             mismatches.append(f"Lanes mismatch: {t_lanes} != {lanes}")
-            
+
         t_sessions = len(get_table(transformer.table_data, "session"))
         if not is_champs and t_sessions != 1:
             mismatches.append(f"Session count mismatch: {t_sessions} != 1 for dual meet")

--- a/backend/src/mm_to_json/reporting/meet_event_writer.py
+++ b/backend/src/mm_to_json/reporting/meet_event_writer.py
@@ -1,0 +1,168 @@
+import logging
+import zipfile
+from datetime import datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class MeetEventWriter:
+    """
+    Generates .ev3 and .hyv files from Meet Manager data for import into Team Manager / TeamUnify.
+    """
+
+    # Stroke mappings from Meet Manager (Letter) to Hy-Tek (Integer)
+    STROKE_MAP = {
+        "A": "1",  # Freestyle
+        "B": "2",  # Backstroke
+        "C": "3",  # Breaststroke
+        "D": "4",  # Butterfly
+        "E": "5",  # Individual Medley
+        "F": "6",  # Freestyle Relay
+        "G": "7",  # Medley Relay
+    }
+
+    def __init__(
+        self,
+        meet_info: dict[str, Any],
+        sessions: list[dict[str, Any]],
+        events: list[dict[str, Any]],
+        scoring: list[dict[str, Any]],
+    ):
+        self.meet_info = meet_info
+        self.sessions = sessions
+        self.events = events
+        self.scoring = scoring
+
+    def _format_date(self, date_val: Any) -> str:
+        """Converts millisecond timestamps or ISO strings to MM/DD/YYYY."""
+        if not date_val:
+            return ""
+        try:
+            if isinstance(date_val, (int, float)):
+                dt = datetime.fromtimestamp(date_val / 1000)
+            else:
+                dt = datetime.strptime(str(date_val).split(" ")[0], "%Y-%m-%d")
+            return dt.strftime("%m/%d/%Y")
+        except Exception as e:
+            logger.warning(f"Could not format date {date_val}: {e}")
+            return str(date_val)
+
+    def _generate_ev3_header(self) -> str:
+        """Generates the EV3 meet header record."""
+        # Reference: Meet Name;Location;Start;End;Age-Up;Course;...
+        fields = [""] * 36
+        fields[0] = str(self.meet_info.get("Meet_name1", ""))
+        fields[1] = str(self.meet_info.get("Meet_location", ""))
+        fields[2] = self._format_date(self.meet_info.get("Meet_start"))
+        fields[3] = self._format_date(self.meet_info.get("Meet_end"))
+        fields[4] = self._format_date(self.meet_info.get("Calc_date"))
+        fields[5] = "YO"  # Yards
+        fields[10] = "Tri-Valley Swim Lg. C"
+        fields[11] = "8.0Gb"  # Version identifier
+        fields[12] = datetime.now().strftime("%m/%d/%Y")
+        fields[16] = self._format_date(self.meet_info.get("Meet_start"))
+        fields[18] = str(self.meet_info.get("indmax_perath", "3"))
+        fields[19] = str(self.meet_info.get("relmax_perath", "2"))
+        fields[20] = str(self.meet_info.get("entrymax_total", "4"))
+        fields[21] = "1"  # ???
+        fields[22] = "A"  # Standard
+        fields[26] = str(self.meet_info.get("Meet_city", "Pleasanton"))
+        fields[27] = str(self.meet_info.get("Meet_state", "CA"))
+        fields[28] = str(self.meet_info.get("Meet_zip", "94566"))
+        fields[29] = "USA"
+        fields[30] = str(self.meet_info.get("Meet_hostlsc", "CC"))
+        fields[33] = self._format_date(self.meet_info.get("Meet_start"))
+
+        return ";".join(fields) + "*>"
+
+    def _generate_ev3_event_record(self, event: dict[str, Any], sess_order: int) -> str:
+        """Generates an EV3 event record."""
+        fields = [""] * 30
+        fields[0] = str(event.get("Event_no", "0"))
+        fields[1] = str(event.get("Event_no", "0"))
+        fields[2] = "F"  # Final
+        fields[3] = str(event.get("Session", "1"))
+        fields[4] = str(event.get("Ind_rel", "I"))
+        fields[5] = str(event.get("Event_sex", "X"))
+        fields[6] = str(event.get("Low_age", "0"))
+        fields[7] = str(event.get("High_Age", "18"))
+        fields[8] = str(event.get("Event_dist", "0"))
+        fields[9] = str(event.get("Event_stroke", "A"))
+        fields[13] = "N"  # Not locked
+        fields[21] = str(sess_order)
+        fields[22] = "1"  # ???
+        fields[23] = "08:00AM"  # Default start
+        fields[24] = "Y"  # Yards
+        fields[28] = "0"
+
+        return ";".join(fields) + "*>"
+
+    def _generate_hyv_header(self) -> str:
+        """Generates the HYV meet header record."""
+        fields = [""] * 12
+        fields[0] = str(self.meet_info.get("Meet_name1", ""))
+        fields[1] = self._format_date(self.meet_info.get("Meet_start"))
+        fields[2] = self._format_date(self.meet_info.get("Meet_end"))
+        fields[3] = self._format_date(self.meet_info.get("Calc_date"))
+        fields[4] = "Y"  # Yards
+        fields[5] = str(self.meet_info.get("Meet_location", ""))
+        fields[7] = "Hy-Tek Sports Software"
+        fields[8] = "8.0Gb"
+        fields[9] = "CN"
+
+        return ";".join(fields)
+
+    def _generate_hyv_event_record(self, event: dict[str, Any]) -> str:
+        """Generates an HYV event record."""
+        fields = [""] * 18
+        fields[0] = str(event.get("Event_no", "0"))
+        fields[1] = "F"  # Rnd
+        fields[2] = str(event.get("Event_sex", "X"))
+        if fields[2] == "G":
+            fields[2] = "F"  # Girls -> Female in HYV?
+        if fields[2] == "B":
+            fields[2] = "M"  # Boys -> Male in HYV?
+
+        fields[3] = str(event.get("Ind_rel", "I"))
+        fields[4] = str(event.get("Low_age", "0"))
+        fields[5] = str(event.get("High_Age", "18"))
+        fields[6] = str(event.get("Event_dist", "0"))
+        fields[7] = self.STROKE_MAP.get(str(event.get("Event_stroke", "A")), "1")
+
+        return ";".join(fields)
+
+    def write_to_zip(self, output_zip_path: str):
+        """Generates the EV3 and HYV files and packages them into a ZIP."""
+        ev3_content = [self._generate_ev3_header()]
+        hyv_content = [self._generate_hyv_header()]
+
+        # Group events by session for order
+        events_by_session = {}
+        for event in self.events:
+            s_id = int(event.get("Session", 1))
+            if s_id not in events_by_session:
+                events_by_session[s_id] = []
+            events_by_session[s_id].append(event)
+
+        for s_id in sorted(events_by_session.keys()):
+            session_events = events_by_session[s_id]
+            # Sort by event number within session
+            session_events.sort(key=lambda x: int(x.get("Event_no", 0)))
+            for i, event in enumerate(session_events, 1):
+                ev3_content.append(self._generate_ev3_event_record(event, sess_order=i))
+                hyv_content.append(self._generate_hyv_event_record(event))
+
+        meet_name = self.meet_info.get("Meet_name1", "Meet").replace(" ", "_")
+        start_date = self._format_date(self.meet_info.get("Meet_start")).replace("/", "")
+        base_name = f"Meet Events-{meet_name}-{start_date}-001"
+
+        ev3_filename = f"{base_name}.ev3"
+        hyv_filename = f"{base_name}.hyv"
+
+        with zipfile.ZipFile(output_zip_path, "w") as zipf:
+            zipf.writestr(ev3_filename, "\n".join(ev3_content) + "\n")
+            zipf.writestr(hyv_filename, "\n".join(hyv_content) + "\n")
+
+        logger.info(f"Generated meet events ZIP: {output_zip_path}")
+        return output_zip_path

--- a/backend/src/mm_to_json/reporting/meet_event_writer.py
+++ b/backend/src/mm_to_json/reporting/meet_event_writer.py
@@ -3,6 +3,11 @@ import zipfile
 from datetime import datetime
 from typing import Any
 
+# Credits:
+# File format specifications (EV3/HYV) derived from research of:
+# - SwimComm/hytek-parser (MIT License)
+# - swimstandards/swimsnap (The Unlicense)
+
 logger = logging.getLogger(__name__)
 
 

--- a/backend/src/mm_to_json/reporting/meet_event_writer.py
+++ b/backend/src/mm_to_json/reporting/meet_event_writer.py
@@ -143,7 +143,7 @@ class MeetEventWriter:
         hyv_content = [self._generate_hyv_header()]
 
         # Group events by session for order
-        events_by_session = {}
+        events_by_session: dict[int, list[dict[str, Any]]] = {}
         for event in self.events:
             s_id = int(event.get("Session", 1))
             if s_id not in events_by_session:

--- a/backend/tests/integration/test_meet_event_export.py
+++ b/backend/tests/integration/test_meet_event_export.py
@@ -1,8 +1,9 @@
 import os
 import zipfile
 
-from season_transformer import SeasonTransformer  # noqa: I001
-from mm_to_json.reporting.meet_event_writer import MeetEventWriter  # noqa: I001
+from mm_to_json.reporting.meet_event_writer import MeetEventWriter
+from season_transformer import SeasonTransformer
+
 
 def test_full_export_flow(tmp_path):
     # 1. Start with raw MDB-like data

--- a/backend/tests/integration/test_meet_event_export.py
+++ b/backend/tests/integration/test_meet_event_export.py
@@ -1,9 +1,8 @@
-import pytest
 import os
-import json
 import zipfile
 from season_transformer import SeasonTransformer
 from mm_to_json.reporting.meet_event_writer import MeetEventWriter
+
 
 def test_full_export_flow(tmp_path):
     # 1. Start with raw MDB-like data
@@ -11,44 +10,61 @@ def test_full_export_flow(tmp_path):
         "MEET": [{"Meet_name1": "Champs 2026", "Meet_start": "2026-07-18", "Meet_numlanes": 10}],
         "TEAM": [{"TCode": "DP", "TName": "Del Prado Stingrays"}],
         "MTEVENT": [
-            {"MtEvent": 1, "Event_no": 1, "Event_stroke": "E", "Ind_rel": "R", "Event_sex": "G", "Low_age": 0, "High_Age": 18, "Event_dist": 100, "Num_prelanes": 10, "Session": 0},
-            {"MtEvent": 2, "Event_no": 2, "Event_stroke": "A", "Ind_rel": "I", "Event_sex": "B", "Low_age": 0, "High_Age": 18, "Event_dist": 50, "Num_prelanes": 10, "Session": 0}
+            {
+                "MtEvent": 1,
+                "Event_no": 1,
+                "Event_stroke": "E",
+                "Ind_rel": "R",
+                "Event_sex": "G",
+                "Low_age": 0,
+                "High_Age": 18,
+                "Event_dist": 100,
+                "Num_prelanes": 10,
+                "Session": 0,
+            },
+            {
+                "MtEvent": 2,
+                "Event_no": 2,
+                "Event_stroke": "A",
+                "Ind_rel": "I",
+                "Event_sex": "B",
+                "Low_age": 0,
+                "High_Age": 18,
+                "Event_dist": 50,
+                "Num_prelanes": 10,
+                "Session": 0,
+            },
         ],
         "Session": [],
-        "Sessitem": []
+        "Sessitem": [],
     }
-    
+
     # 2. Transform (Season Setup Logic)
     transformer = SeasonTransformer(table_data)
-    transformer.update_meet(
-        name="TVSL Championships",
-        start_date="2026-07-18",
-        lanes=10,
-        is_champs=True
-    )
+    transformer.update_meet(name="TVSL Championships", start_date="2026-07-18", lanes=10, is_champs=True)
     transformer.consolidate_sessions(is_champs=True)
-    
+
     # 3. Export
     transformed_data = transformer.table_data
     writer = MeetEventWriter(
         meet_info=transformed_data["MEET"][0],
         sessions=transformed_data["Session"],
         events=transformed_data["MTEVENT"],
-        scoring=[] # Not strictly needed for EV3
+        scoring=[],  # Not strictly needed for EV3
     )
-    
+
     zip_path = str(tmp_path / "Champs_Export.zip")
     writer.write_to_zip(zip_path)
-    
+
     # 4. Verify ZIP
     assert os.path.exists(zip_path)
-    with zipfile.ZipFile(zip_path, 'r') as zipf:
+    with zipfile.ZipFile(zip_path, "r") as zipf:
         ev3_name = [n for n in zipf.namelist() if n.endswith(".ev3")][0]
         content = zipf.read(ev3_name).decode("utf-8")
-        
+
         # Verify meet info
         assert "TVSL Championships" in content
-        
+
         # Verify session mapping (Med Relays -> Session 1)
         # 1;1;F;1;R;G;0;18;100;E
         assert "1;1;F;1;R;G;0;18;100;E" in content

--- a/backend/tests/integration/test_meet_event_export.py
+++ b/backend/tests/integration/test_meet_event_export.py
@@ -1,0 +1,57 @@
+import pytest
+import os
+import json
+import zipfile
+from season_transformer import SeasonTransformer
+from mm_to_json.reporting.meet_event_writer import MeetEventWriter
+
+def test_full_export_flow(tmp_path):
+    # 1. Start with raw MDB-like data
+    table_data = {
+        "MEET": [{"Meet_name1": "Champs 2026", "Meet_start": "2026-07-18", "Meet_numlanes": 10}],
+        "TEAM": [{"TCode": "DP", "TName": "Del Prado Stingrays"}],
+        "MTEVENT": [
+            {"MtEvent": 1, "Event_no": 1, "Event_stroke": "E", "Ind_rel": "R", "Event_sex": "G", "Low_age": 0, "High_Age": 18, "Event_dist": 100, "Num_prelanes": 10, "Session": 0},
+            {"MtEvent": 2, "Event_no": 2, "Event_stroke": "A", "Ind_rel": "I", "Event_sex": "B", "Low_age": 0, "High_Age": 18, "Event_dist": 50, "Num_prelanes": 10, "Session": 0}
+        ],
+        "Session": [],
+        "Sessitem": []
+    }
+    
+    # 2. Transform (Season Setup Logic)
+    transformer = SeasonTransformer(table_data)
+    transformer.update_meet(
+        name="TVSL Championships",
+        start_date="2026-07-18",
+        lanes=10,
+        is_champs=True
+    )
+    transformer.consolidate_sessions(is_champs=True)
+    
+    # 3. Export
+    transformed_data = transformer.table_data
+    writer = MeetEventWriter(
+        meet_info=transformed_data["MEET"][0],
+        sessions=transformed_data["Session"],
+        events=transformed_data["MTEVENT"],
+        scoring=[] # Not strictly needed for EV3
+    )
+    
+    zip_path = str(tmp_path / "Champs_Export.zip")
+    writer.write_to_zip(zip_path)
+    
+    # 4. Verify ZIP
+    assert os.path.exists(zip_path)
+    with zipfile.ZipFile(zip_path, 'r') as zipf:
+        ev3_name = [n for n in zipf.namelist() if n.endswith(".ev3")][0]
+        content = zipf.read(ev3_name).decode("utf-8")
+        
+        # Verify meet info
+        assert "TVSL Championships" in content
+        
+        # Verify session mapping (Med Relays -> Session 1)
+        # 1;1;F;1;R;G;0;18;100;E
+        assert "1;1;F;1;R;G;0;18;100;E" in content
+        # Verify Freestyle -> Session 2
+        # 2;2;F;2;I;B;0;18;50;A
+        assert "2;2;F;2;I;B;0;18;50;A" in content

--- a/backend/tests/integration/test_meet_event_export.py
+++ b/backend/tests/integration/test_meet_event_export.py
@@ -1,7 +1,8 @@
 import os
 import zipfile
-from season_transformer import SeasonTransformer
+
 from mm_to_json.reporting.meet_event_writer import MeetEventWriter
+from season_transformer import SeasonTransformer
 
 
 def test_full_export_flow(tmp_path):

--- a/backend/tests/integration/test_meet_event_export.py
+++ b/backend/tests/integration/test_meet_event_export.py
@@ -1,8 +1,9 @@
 import os
 import zipfile
 
-from mm_to_json.reporting.meet_event_writer import MeetEventWriter
-from season_transformer import SeasonTransformer
+from season_transformer import SeasonTransformer  # noqa: I001
+
+from mm_to_json.reporting.meet_event_writer import MeetEventWriter  # noqa: I001
 
 
 def test_full_export_flow(tmp_path):

--- a/backend/tests/integration/test_meet_event_export.py
+++ b/backend/tests/integration/test_meet_event_export.py
@@ -1,9 +1,8 @@
 import os
 import zipfile
 
-from mm_to_json.reporting.meet_event_writer import MeetEventWriter
-from season_transformer import SeasonTransformer
-
+from season_transformer import SeasonTransformer  # noqa: I001
+from mm_to_json.reporting.meet_event_writer import MeetEventWriter  # noqa: I001
 
 def test_full_export_flow(tmp_path):
     # 1. Start with raw MDB-like data

--- a/backend/tests/integration/test_season_setup_hermetic.py
+++ b/backend/tests/integration/test_season_setup_hermetic.py
@@ -117,4 +117,3 @@ def test_generate_season_logic_hermetic(mock_restore, tmp_path):
     assert mock_restore.called
     _, target_path = mock_restore.call_args[0]
     assert "2026-05-30 FAST vs Del Prado-audit-v4.mdb" in target_path
-

--- a/backend/tests/integration/test_season_setup_hermetic.py
+++ b/backend/tests/integration/test_season_setup_hermetic.py
@@ -116,4 +116,5 @@ def test_generate_season_logic_hermetic(mock_restore, tmp_path):
 
     assert mock_restore.called
     _, target_path = mock_restore.call_args[0]
-    assert "2026-05-30 FAST vs Del Prado.mdb" in target_path
+    assert "2026-05-30 FAST vs Del Prado-audit-v4.mdb" in target_path
+

--- a/backend/tests/reporting/test_meet_event_writer.py
+++ b/backend/tests/reporting/test_meet_event_writer.py
@@ -1,4 +1,3 @@
-import os
 from mm_to_json.reporting.meet_event_writer import MeetEventWriter
 
 
@@ -109,13 +108,14 @@ def test_write_to_zip(tmp_path):
         }
     ]
 
+    import os
+    import zipfile
+
     output_path = str(tmp_path / "test_export.zip")
     writer = MeetEventWriter(meet_info=meet_info, sessions=[], events=events, scoring=[])
     writer.write_to_zip(output_path)
 
     assert os.path.exists(output_path)
-
-    import zipfile
 
     with zipfile.ZipFile(output_path, "r") as zipf:
         namelist = zipf.namelist()

--- a/backend/tests/reporting/test_meet_event_writer.py
+++ b/backend/tests/reporting/test_meet_event_writer.py
@@ -1,7 +1,6 @@
-import pytest
 import os
-from season_transformer import SeasonTransformer
 from mm_to_json.reporting.meet_event_writer import MeetEventWriter
+
 
 def test_generate_ev3_header():
     meet_info = {
@@ -16,12 +15,12 @@ def test_generate_ev3_header():
         "Meet_hostlsc": "CC",
         "indmax_perath": 3,
         "relmax_perath": 2,
-        "entrymax_total": 4
+        "entrymax_total": 4,
     }
-    
+
     writer = MeetEventWriter(meet_info=meet_info, sessions=[], events=[], scoring=[])
     header = writer._generate_ev3_header()
-    
+
     # Check key components in the semicolon-delimited string
     parts = header.split(";")
     assert parts[0] == "Test Meet"
@@ -30,6 +29,7 @@ def test_generate_ev3_header():
     assert parts[26] == "Pleasanton"
     assert parts[27] == "CA"
     assert parts[30] == "CC"
+
 
 def test_generate_ev3_event_record():
     event = {
@@ -42,36 +42,34 @@ def test_generate_ev3_event_record():
         "Event_dist": 100,
         "Event_stroke": "E",
         "Num_prelanes": 8,
-        "Session": 1
+        "Session": 1,
     }
-    
+
     writer = MeetEventWriter(meet_info={}, sessions=[], events=[], scoring=[])
     record = writer._generate_ev3_event_record(event, sess_order=1)
-    
+
     parts = record.split(";")
-    assert parts[0] == "5" # Event No
-    assert parts[3] == "1" # Session
-    assert parts[4] == "R" # Relay
-    assert parts[5] == "G" # Girls
-    assert parts[6] == "9" # Low Age
-    assert parts[7] == "10" # High Age
-    assert parts[8] == "100" # Distance
-    assert parts[9] == "E" # Stroke
-    assert parts[21] == "1" # Sess Order
+    assert parts[0] == "5"  # Event No
+    assert parts[3] == "1"  # Session
+    assert parts[4] == "R"  # Relay
+    assert parts[5] == "G"  # Girls
+    assert parts[6] == "9"  # Low Age
+    assert parts[7] == "10"  # High Age
+    assert parts[8] == "100"  # Distance
+    assert parts[9] == "E"  # Stroke
+    assert parts[21] == "1"  # Sess Order
+
 
 def test_generate_hyv_header():
-    meet_info = {
-        "Meet_name1": "Test Meet",
-        "Meet_start": "2026-06-01",
-        "Meet_location": "Test Pool"
-    }
+    meet_info = {"Meet_name1": "Test Meet", "Meet_start": "2026-06-01", "Meet_location": "Test Pool"}
     writer = MeetEventWriter(meet_info=meet_info, sessions=[], events=[], scoring=[])
     header = writer._generate_hyv_header()
-    
+
     parts = header.split(";")
     assert parts[0] == "Test Meet"
     assert "06/01/2026" in parts[1]
     assert parts[5] == "Test Pool"
+
 
 def test_generate_hyv_event_record():
     event = {
@@ -81,11 +79,11 @@ def test_generate_hyv_event_record():
         "Low_age": 0,
         "High_Age": 6,
         "Event_dist": 25,
-        "Event_stroke": "A"
+        "Event_stroke": "A",
     }
     writer = MeetEventWriter(meet_info={}, sessions=[], events=[], scoring=[])
     record = writer._generate_hyv_event_record(event)
-    
+
     parts = record.split(";")
     assert parts[0] == "13"
     assert parts[2] == "F"
@@ -93,25 +91,38 @@ def test_generate_hyv_event_record():
     assert parts[4] == "0"
     assert parts[5] == "6"
     assert parts[6] == "25"
-    assert parts[7] == "1" # Stroke A -> 1 (Free)
+    assert parts[7] == "1"  # Stroke A -> 1 (Free)
+
 
 def test_write_to_zip(tmp_path):
     meet_info = {"Meet_name1": "Test Meet", "Meet_start": "2026-06-01"}
-    events = [{"Event_no": 1, "Session": 1, "Ind_rel": "I", "Event_sex": "F", "Low_age": 0, "High_Age": 18, "Event_dist": 50, "Event_stroke": "A"}]
-    
+    events = [
+        {
+            "Event_no": 1,
+            "Session": 1,
+            "Ind_rel": "I",
+            "Event_sex": "F",
+            "Low_age": 0,
+            "High_Age": 18,
+            "Event_dist": 50,
+            "Event_stroke": "A",
+        }
+    ]
+
     output_path = str(tmp_path / "test_export.zip")
     writer = MeetEventWriter(meet_info=meet_info, sessions=[], events=events, scoring=[])
     writer.write_to_zip(output_path)
-    
+
     assert os.path.exists(output_path)
-    
+
     import zipfile
-    with zipfile.ZipFile(output_path, 'r') as zipf:
+
+    with zipfile.ZipFile(output_path, "r") as zipf:
         namelist = zipf.namelist()
         assert len(namelist) == 2
         assert any(n.endswith(".ev3") for n in namelist)
         assert any(n.endswith(".hyv") for n in namelist)
-        
+
         # Verify content of EV3
         ev3_name = [n for n in namelist if n.endswith(".ev3")][0]
         content = zipf.read(ev3_name).decode("utf-8")

--- a/backend/tests/reporting/test_meet_event_writer.py
+++ b/backend/tests/reporting/test_meet_event_writer.py
@@ -1,7 +1,7 @@
 import os
 import zipfile
 
-from mm_to_json.reporting.meet_event_writer import MeetEventWriter  # noqa: I001
+from mm_to_json.reporting.meet_event_writer import MeetEventWriter
 
 
 def test_generate_ev3_header():

--- a/backend/tests/reporting/test_meet_event_writer.py
+++ b/backend/tests/reporting/test_meet_event_writer.py
@@ -1,4 +1,7 @@
-from mm_to_json.reporting.meet_event_writer import MeetEventWriter
+import os
+import zipfile
+
+from mm_to_json.reporting.meet_event_writer import MeetEventWriter  # noqa: I001
 
 
 def test_generate_ev3_header():
@@ -107,9 +110,6 @@ def test_write_to_zip(tmp_path):
             "Event_stroke": "A",
         }
     ]
-
-    import os
-    import zipfile
 
     output_path = str(tmp_path / "test_export.zip")
     writer = MeetEventWriter(meet_info=meet_info, sessions=[], events=events, scoring=[])

--- a/backend/tests/reporting/test_meet_event_writer.py
+++ b/backend/tests/reporting/test_meet_event_writer.py
@@ -1,0 +1,119 @@
+import pytest
+import os
+from season_transformer import SeasonTransformer
+from mm_to_json.reporting.meet_event_writer import MeetEventWriter
+
+def test_generate_ev3_header():
+    meet_info = {
+        "Meet_name1": "Test Meet",
+        "Meet_location": "Test Pool",
+        "Meet_start": "2026-06-01",
+        "Meet_end": "2026-06-01",
+        "Calc_date": "2026-06-01",
+        "Meet_city": "Pleasanton",
+        "Meet_state": "CA",
+        "Meet_zip": "94566",
+        "Meet_hostlsc": "CC",
+        "indmax_perath": 3,
+        "relmax_perath": 2,
+        "entrymax_total": 4
+    }
+    
+    writer = MeetEventWriter(meet_info=meet_info, sessions=[], events=[], scoring=[])
+    header = writer._generate_ev3_header()
+    
+    # Check key components in the semicolon-delimited string
+    parts = header.split(";")
+    assert parts[0] == "Test Meet"
+    assert parts[1] == "Test Pool"
+    assert "06/01/2026" in parts[2]
+    assert parts[26] == "Pleasanton"
+    assert parts[27] == "CA"
+    assert parts[30] == "CC"
+
+def test_generate_ev3_event_record():
+    event = {
+        "Event_no": 5,
+        "Event_ptr": 5,
+        "Ind_rel": "R",
+        "Event_sex": "G",
+        "Low_age": 9,
+        "High_Age": 10,
+        "Event_dist": 100,
+        "Event_stroke": "E",
+        "Num_prelanes": 8,
+        "Session": 1
+    }
+    
+    writer = MeetEventWriter(meet_info={}, sessions=[], events=[], scoring=[])
+    record = writer._generate_ev3_event_record(event, sess_order=1)
+    
+    parts = record.split(";")
+    assert parts[0] == "5" # Event No
+    assert parts[3] == "1" # Session
+    assert parts[4] == "R" # Relay
+    assert parts[5] == "G" # Girls
+    assert parts[6] == "9" # Low Age
+    assert parts[7] == "10" # High Age
+    assert parts[8] == "100" # Distance
+    assert parts[9] == "E" # Stroke
+    assert parts[21] == "1" # Sess Order
+
+def test_generate_hyv_header():
+    meet_info = {
+        "Meet_name1": "Test Meet",
+        "Meet_start": "2026-06-01",
+        "Meet_location": "Test Pool"
+    }
+    writer = MeetEventWriter(meet_info=meet_info, sessions=[], events=[], scoring=[])
+    header = writer._generate_hyv_header()
+    
+    parts = header.split(";")
+    assert parts[0] == "Test Meet"
+    assert "06/01/2026" in parts[1]
+    assert parts[5] == "Test Pool"
+
+def test_generate_hyv_event_record():
+    event = {
+        "Event_no": 13,
+        "Ind_rel": "I",
+        "Event_sex": "F",
+        "Low_age": 0,
+        "High_Age": 6,
+        "Event_dist": 25,
+        "Event_stroke": "A"
+    }
+    writer = MeetEventWriter(meet_info={}, sessions=[], events=[], scoring=[])
+    record = writer._generate_hyv_event_record(event)
+    
+    parts = record.split(";")
+    assert parts[0] == "13"
+    assert parts[2] == "F"
+    assert parts[3] == "I"
+    assert parts[4] == "0"
+    assert parts[5] == "6"
+    assert parts[6] == "25"
+    assert parts[7] == "1" # Stroke A -> 1 (Free)
+
+def test_write_to_zip(tmp_path):
+    meet_info = {"Meet_name1": "Test Meet", "Meet_start": "2026-06-01"}
+    events = [{"Event_no": 1, "Session": 1, "Ind_rel": "I", "Event_sex": "F", "Low_age": 0, "High_Age": 18, "Event_dist": 50, "Event_stroke": "A"}]
+    
+    output_path = str(tmp_path / "test_export.zip")
+    writer = MeetEventWriter(meet_info=meet_info, sessions=[], events=events, scoring=[])
+    writer.write_to_zip(output_path)
+    
+    assert os.path.exists(output_path)
+    
+    import zipfile
+    with zipfile.ZipFile(output_path, 'r') as zipf:
+        namelist = zipf.namelist()
+        assert len(namelist) == 2
+        assert any(n.endswith(".ev3") for n in namelist)
+        assert any(n.endswith(".hyv") for n in namelist)
+        
+        # Verify content of EV3
+        ev3_name = [n for n in namelist if n.endswith(".ev3")][0]
+        content = zipf.read(ev3_name).decode("utf-8")
+        assert "Test Meet" in content
+        assert "1;1;F;1;I;F;0;18;50;A" in content

--- a/backend/tests/test_season_transformer_robust.py
+++ b/backend/tests/test_season_transformer_robust.py
@@ -18,10 +18,11 @@ def test_scoring_champs():
     assert scoring[11]["ind_score"] == 5.0
     assert scoring[15]["ind_score"] == 1.0
 
-    # Relays: 5 places (40, 34, 32, 30, 28)
+    # Relays: 8 places (40, 34, 32, 30, 28, 26, 24, 22)
     assert scoring[0]["rel_score"] == 40.0
     assert scoring[4]["rel_score"] == 28.0
-    assert scoring[5]["rel_score"] == 0.0
+    assert scoring[7]["rel_score"] == 22.0
+    assert scoring[8]["rel_score"] == 0.0
 
 
 def test_lane_settings_robust():


### PR DESCRIPTION
This PR implements the automated generation of "Meet Events-" ZIP files (containing `.ev3` and `.hyv` files) as part of the season setup workflow. This automates the "Export to Team Manager" manual step.

### Key Changes:
- **`MeetEventWriter`**: A new class that generates the semicolon-delimited Hy-Tek formats directly from internal MDB data.
- **`generate_season.py` Integration**: Automatically triggers the export for every meet generated.
- **TDD Verification**: 
  - Unit tests for header and record generation.
  - Integration tests for the full flow (MDB -> Transformation -> ZIP).
- **Justfile**: Added `just test-season-setup` target.

Closes #422