### PR TITLE
Fix entry open date logic for subsequent meets

### DIFF
--- a/backend/scripts/season_setup/generate_season.py
+++ b/backend/scripts/season_setup/generate_season.py
@@ -141,6 +141,7 @@ def generate(template_path, output_dir, year, owner_team="DP"):
             except Exception:
                 entry_open = "2025-06-01"
         else:
+            # All subsequent meets use the first meet's date to pull current season times
             entry_open = first_meet_date
 
         meet_dt = datetime.strptime(meet["date"], "%Y-%m-%d")

--- a/backend/tests/reporting/test_meet_event_writer.py
+++ b/backend/tests/reporting/test_meet_event_writer.py
@@ -18,7 +18,7 @@ def test_generate_ev3_header():
         "indmax_perath": 3,
         "relmax_perath": 2,
         "entrymax_total": 4,
-        "entry_deadline": "2026-05-26"
+        "entry_deadline": "2026-05-26",
     }
 
     writer = MeetEventWriter(meet_info=meet_info, sessions=[], events=[], scoring=[])
@@ -32,9 +32,9 @@ def test_generate_ev3_header():
     assert parts[6] == "0"
     assert parts[9] == "Created by Hy-Tek's MEET MANAGER"
     assert parts[11] == "7.0Gb"
-    assert parts[13] == "4" # entrymax_total
-    assert parts[20] == "3" # indmax_perath
-    assert parts[21] == "2" # relmax_perath
+    assert parts[13] == "4"  # entrymax_total
+    assert parts[20] == "3"  # indmax_perath
+    assert parts[21] == "2"  # relmax_perath
 
     assert parts[23] == "05/26/2026"  # entry_deadline
     assert parts[26] == "Pleasanton"


### PR DESCRIPTION
This PR updates the entry open logic to use the first meet's date (5/30/2026) for all meets after the first one. This ensures that entry times are pulled from the current season rather than the previous one.