### PR TITLE
Correct EV3 header field mapping

### DIFF
--- a/backend/src/mm_to_json/reporting/meet_event_writer.py
+++ b/backend/src/mm_to_json/reporting/meet_event_writer.py
@@ -76,7 +76,7 @@ class MeetEventWriter:
         fields[10] = "Tri-Valley Swim Lg. C"
         fields[11] = "7.0Gb"
         fields[12] = datetime.now().strftime("%m/%d/%Y")
-        fields[13] = str(self._get_meet_prop("entrymax_total", "4"))
+        fields[13] = str(self._get_meet_prop("indmax_perath", "3"))
         fields[15] = "0"
 
         # Field 16 seems to be a fixed date in manual exports (06/01/2025)
@@ -92,10 +92,10 @@ class MeetEventWriter:
             fields[16] = "06/01/2025"
 
         fields[17] = "0"
-        fields[18] = str(self._get_meet_prop("indmaxscorers_perteam", "4"))
-        fields[19] = str(self._get_meet_prop("relmaxscorers_perteam", "3"))
-        fields[20] = str(self._get_meet_prop("indmax_perath", "2"))
-        fields[21] = str(self._get_meet_prop("relmax_perath", "1"))
+        fields[18] = str(self._get_meet_prop("entrymax_total", "4"))
+        fields[19] = str(self._get_meet_prop("indmax_perath", "3"))
+        fields[20] = str(self._get_meet_prop("relmax_perath", "2"))
+        fields[21] = str(self._get_meet_prop("relmaxscorers_perteam", "1"))
         fields[22] = "A"
         fields[23] = self._format_date(self._get_meet_prop("entry_deadline"))
         fields[24] = str(self._get_meet_prop("Meet_addr1", ""))

--- a/backend/tests/reporting/test_meet_event_writer.py
+++ b/backend/tests/reporting/test_meet_event_writer.py
@@ -32,11 +32,14 @@ def test_generate_ev3_header():
     assert parts[6] == "0"
     assert parts[9] == "Created by Hy-Tek's MEET MANAGER"
     assert parts[11] == "7.0Gb"
-    assert parts[13] == "4"  # entrymax_total
-    assert parts[20] == "3"  # indmax_perath
-    assert parts[21] == "2"  # relmax_perath
+    assert parts[13] == "3" # indmax_perath (legacy/duplicated)
+    assert parts[18] == "4" # entrymax_total
+    assert parts[19] == "3" # indmax_perath
+    assert parts[20] == "2" # relmax_perath
+    assert parts[21] == "1" # relmaxscorers_perteam
 
     assert parts[23] == "05/26/2026"  # entry_deadline
+
     assert parts[26] == "Pleasanton"
     assert parts[30] == "CC"
 


### PR DESCRIPTION
This PR fixes the EV3 header mapping based on empirical evidence from manual Meet Manager exports. It correctly assigns Total Entries to Index 18, Individual Entries to Index 19 (and 13), and Relay Scorers to Index 21.