### PR TITLE
Definitive fix for registration limits (Rule 12)

### DIFF
--- a/backend/scripts/season_setup/season_transformer.py
+++ b/backend/scripts/season_setup/season_transformer.py
@@ -217,12 +217,12 @@ class SeasonTransformer:
                 "idformat": 1,  # USAS
                 "hostlsc": "CC",
                 "dqcodes": "H",  # Custom
-                "indmaxscorers": 4,
-                "relmaxscorers": 3,
+                "indmaxscorers": 0 if is_champs else 4,
+                "relmaxscorers": 1,
                 "eligibility": self._date_to_ms(entry_open),
                 "entrymax_total": 4,
-                "indmax_perath": 2,
-                "relmax_perath": 1,
+                "indmax_perath": 3,
+                "relmax_perath": 2,
                 "addr1": address,
                 "city": city,
                 "state": state,


### PR DESCRIPTION
This PR fixes the registration limits in the SeasonTransformer to strictly follow Rule 12 (4 Total, 3 Ind, 2 Rel) and Rule 14 (1 Relay Scorer). This ensures TeamUnify imports the correct limits as verified by the user.