### PR TITLE
Fix: Meet Program PDF revisions

### DIFF
--- a/backend/scripts/season_setup/season_transformer.py
+++ b/backend/scripts/season_setup/season_transformer.py
@@ -216,13 +216,13 @@ class SeasonTransformer:
         })
         presets.append(report)
 
-        # Boys only
+        # Boys + Mixed
         report = self.DEFAULT_REPORT.copy()
         report.update({
-            "Mem_Name": "Posting: Boys only",
+            "Mem_Name": "Posting: Boys+Mixed",
             "Mem_Type": 4,
             "Num_Columns": 2,
-            "Evt_Gender": 1, # Male
+            "Evt_Gender": 0, # All/Boys+Mixed
             "Show_SeedTimes": 1,
             "Incl_Records": 1,
             "Sess_Row": 1,

--- a/backend/scripts/season_setup/test_season_transformer.py
+++ b/backend/scripts/season_setup/test_season_transformer.py
@@ -147,6 +147,7 @@ def test_inject_memorized_reports(sample_data):
     assert "Lineup: 6&U" in report_names
     assert "Results: Coach" in report_names
     assert "Posting: Girls only" in report_names
+    assert "Posting: Boys+Mixed" in report_names
 
     # Check DP filter
     lineup_6u = next(r for r in reports if r["Mem_Name"] == "Lineup: 6&U")

--- a/backend/src/mm_to_json/mm_to_json.py
+++ b/backend/src/mm_to_json/mm_to_json.py
@@ -1023,11 +1023,20 @@ class MmToJsonConverter:
                     team_no = self._safe_int(row.get("team_no") or row.get("team1"))
 
                     team_info = self.get_team_info(team_no)
+
+                    # Support for preferred name / short name (Pref_name in Schema A)
+                    first_name = self._get_val(row, "first_name") or self._get_val(row, "first")
+                    pref_name = self._get_val(row, "pref_name")
+                    if pref_name and str(pref_name).strip():
+                        first_name = str(pref_name).strip()
+
+                    last_name = self._get_val(row, "last_name") or self._get_val(row, "last")
+
                     self.cache_athlete_map[aid] = {
                         "athleteId": aid,
-                        "firstName": self._get_val(row, "first_name") or self._get_val(row, "first"),
-                        "lastName": self._get_val(row, "last_name") or self._get_val(row, "last"),
-                        "name": f"{self._get_val(row, 'first_name') or self._get_val(row, 'first')} {self._get_val(row, 'last_name') or self._get_val(row, 'last')}",
+                        "firstName": first_name,
+                        "lastName": last_name,
+                        "name": f"{first_name} {last_name}",
                         "age": self._safe_int(row.get("ath_age") or row.get("age")),
                         "athleteSex": self._get_val(row, "sex"),
                         "schoolYear": self._get_val(row, "schl_yr") or self._get_val(row, "class"),
@@ -1088,7 +1097,7 @@ class MmToJsonConverter:
             val = float(num)
             if val <= 0:
                 return "NT"
-            return f"{val:.3f}"
+            return f"{val:.2f}"
         except (ValueError, TypeError):
             return "NT"
 
@@ -1106,7 +1115,7 @@ class MmToJsonConverter:
             val = float(time_val or 0.0)
             if val <= 0:
                 return "NT"
-            return f"{val:.3f}"
+            return f"{val:.2f}"
         except (ValueError, TypeError):
             return "NT"
 
@@ -1124,15 +1133,15 @@ class MmToJsonConverter:
         try:
             val = float(time_str)
             seconds = int(val)
-            # Support thousandths
-            ms = int(round((val - seconds) * 1000))
+            # Support hundredths
+            ms = int(round((val - seconds) * 100))
             minutes = seconds // 60
             rem_seconds = seconds % 60
 
             if minutes > 0:
-                return f"{minutes}:{rem_seconds:02d}.{ms:03d}"
+                return f"{minutes}:{rem_seconds:02d}.{ms:02d}"
             else:
-                return f"{rem_seconds:02d}.{ms:03d}"
+                return f"{rem_seconds:02d}.{ms:02d}"
         except Exception:
             return time_str
 

--- a/backend/src/mm_to_json/reporting/extractor.py
+++ b/backend/src/mm_to_json/reporting/extractor.py
@@ -399,7 +399,9 @@ class ReportDataExtractor:
                             if is_mixed and age_val:
                                 gender_pref = str(a.get("athleteSex", ""))[:1].upper()
                                 age_str = f"{gender_pref}{age_str}"
-                            names.append(f"{a.get('lastName', '').strip()}, {a.get('firstName', '').strip()} {age_str}".strip())
+                            names.append(
+                                f"{a.get('lastName', '').strip()}, {a.get('firstName', '').strip()} {age_str}".strip()
+                            )
                     else:
                         names = [n.strip() for n in r.get("name", "").split(",")]
 
@@ -510,14 +512,16 @@ class ReportDataExtractor:
                         names = []
                         if show_relay_swimmers:
                             if "relayAthletes" in entry:
-                                is_mixed = str(event.get("Event_sex", "")).upper() == "X"
+                                is_mixed = str(evt.get("gender", "")).upper() == "X"
                                 for a in entry["relayAthletes"]:
                                     age_val = a.get("age", "")
                                     age_str = str(age_val)
                                     if is_mixed and age_val:
                                         gender_pref = str(a.get("athleteSex", ""))[:1].upper()
                                         age_str = f"{gender_pref}{age_str}"
-                                    names.append(f"{a.get('lastName', '').strip()}, {a.get('firstName', '').strip()} {age_str}".strip())
+                                    names.append(
+                                        f"{a.get('lastName', '').strip()}, {a.get('firstName', '').strip()} {age_str}".strip()
+                                    )
                             else:
                                 names = [n.strip() for n in entry.get("name", "").split(",")]
                         sub_items.append(

--- a/backend/src/mm_to_json/reporting/extractor.py
+++ b/backend/src/mm_to_json/reporting/extractor.py
@@ -392,10 +392,14 @@ class ReportDataExtractor:
 
                     names = []
                     if "relayAthletes" in r:
-                        names = [
-                            f"{a.get('lastName', '').strip()}, {a.get('firstName', '').strip()}"
-                            for a in r["relayAthletes"]
-                        ]
+                        is_mixed = str(r.get("event_sex", "")).upper() == "X"
+                        for a in r["relayAthletes"]:
+                            age_val = a.get("age", "")
+                            age_str = str(age_val)
+                            if is_mixed and age_val:
+                                gender_pref = str(a.get("athleteSex", ""))[:1].upper()
+                                age_str = f"{gender_pref}{age_str}"
+                            names.append(f"{a.get('lastName', '').strip()}, {a.get('firstName', '').strip()} {age_str}".strip())
                     else:
                         names = [n.strip() for n in r.get("name", "").split(",")]
 
@@ -506,10 +510,14 @@ class ReportDataExtractor:
                         names = []
                         if show_relay_swimmers:
                             if "relayAthletes" in entry:
-                                names = [
-                                    f"{a.get('lastName', '').strip()}, {a.get('firstName', '').strip()}"
-                                    for a in entry["relayAthletes"]
-                                ]
+                                is_mixed = str(event.get("Event_sex", "")).upper() == "X"
+                                for a in entry["relayAthletes"]:
+                                    age_val = a.get("age", "")
+                                    age_str = str(age_val)
+                                    if is_mixed and age_val:
+                                        gender_pref = str(a.get("athleteSex", ""))[:1].upper()
+                                        age_str = f"{gender_pref}{age_str}"
+                                    names.append(f"{a.get('lastName', '').strip()}, {a.get('firstName', '').strip()} {age_str}".strip())
                             else:
                                 names = [n.strip() for n in entry.get("name", "").split(",")]
                         sub_items.append(

--- a/backend/src/mm_to_json/reporting/playwright_renderer.py
+++ b/backend/src/mm_to_json/reporting/playwright_renderer.py
@@ -3,6 +3,7 @@ import datetime
 import os
 from typing import Any
 
+import pytz
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 
@@ -28,10 +29,10 @@ class PlaywrightRenderer:
         render_data = copy.copy(data)
         render_data["css_content"] = css_content
         render_data["playwright"] = True
-        import pytz
 
         tz = pytz.timezone("America/Los_Angeles")
-        render_data["generation_time"] = datetime.datetime.now(tz).strftime("%I:%M %p %Y/%m/%d")
+        # Format like MM: "2:17 PM 5/29/2026"
+        render_data["generation_time"] = datetime.datetime.now(tz).strftime("%-I:%M %p %-m/%-d/%Y")
 
         return template.render(**render_data)
 
@@ -50,18 +51,20 @@ class PlaywrightRenderer:
             # Native Header Template (Chromium specific)
             # Use data-passed titles or fallback
             display_meet = meet_name or "Meet Manager Tools"
-            display_sub = sub_title or "Report"
+
+            tz = pytz.timezone("America/Los_Angeles")
+            gen_time = datetime.datetime.now(tz).strftime("%-I:%M %p %-m/%-d/%Y")
 
             header_html = f"""
             <div style="font-family: Helvetica, Arial, sans-serif; font-size: 8pt; width: 100%; margin: 0 0.5in; border-bottom: 0.5pt solid #000; padding-bottom: 3pt;">
                 <div style="display: flex; justify-content: space-between; align-items: flex-end; width: 100%;">
                     <div style="text-align: left;">
-                        <div style="font-weight: bold;">{display_meet}</div>
-                        <div>{display_sub}</div>
+                        <div style="font-weight: bold;">Tri-Valley Swim Lg. C</div>
+                        <div>{display_meet}</div>
                     </div>
                     <div style="text-align: right;">
-                        <div>MM-Tools</div>
-                        <div>Page <span class="pageNumber"></span> of <span class="totalPages"></span></div>
+                        <div>HY-TEK's MEET MANAGER 7.0 - {gen_time}</div>
+                        <div>Page <span class="pageNumber"></span></div>
                     </div>
                 </div>
             </div>

--- a/backend/src/mm_to_json/reporting/templates/_base_report.j2
+++ b/backend/src/mm_to_json/reporting/templates/_base_report.j2
@@ -26,12 +26,24 @@
         <table class="header-table">
             <tr class="header-top">
                 <td class="header-left-col">
-                    <div class="header-meet-name">{{ meet_name|default('Tri-Valley Swim League') }}</div>
+                    <div class="header-meet-name">Tri-Valley Swim Lg. C</div>
+                </td>
+                <td class="header-right-col">
+                    <div class="header-software">HY-TEK's MEET MANAGER 7.0 - {{ generation_time }} Page <span class="page-counter"></span></div>
+                </td>
+            </tr>
+            <tr>
+                <td class="header-left-col">
+                    <div class="header-meet-info">{{ meet_name }}</div>
+                </td>
+                <td class="header-right-col">
+                </td>
+            </tr>
+            <tr>
+                <td class="header-left-col">
                     <div class="header-sub-title">{{ sub_title }}</div>
                 </td>
                 <td class="header-right-col">
-                    <div class="header-timestamp">MM-Tools - {{ generation_time }}</div>
-                    <div class="header-page-num">Page <span class="page-counter"></span></div>
                 </td>
             </tr>
         </table>

--- a/backend/src/mm_to_json/reporting/templates/meet_program.j2
+++ b/backend/src/mm_to_json/reporting/templates/meet_program.j2
@@ -16,14 +16,14 @@
                         <div class="div-col col-lane">Lane</div>
                         <div class="div-col col-team">Team</div>
                         <div class="div-col col-relay">Relay</div>
-                        <div class="div-col col-time">Seed</div>
+                        <div class="div-col col-time">Seed Time</div>
                         {% if show_dq_lines %}<div class="div-col col-dq dq-centered">DQ</div>{% endif %}
                     {% else %}
                         <div class="div-col col-lane">Lane</div>
                         <div class="div-col col-name">Name</div>
                         <div class="div-col col-age">Age</div>
                         <div class="div-col col-team">Team</div>
-                        <div class="div-col col-time">Seed</div>
+                        <div class="div-col col-time">Seed Time</div>
                         {% if show_dq_lines %}<div class="div-col col-dq-limited dq-centered">DQ</div>{% endif %}
                     {% endif %}
                 </div>

--- a/backend/src/mm_to_json/reporting/templates/report_style.css
+++ b/backend/src/mm_to_json/reporting/templates/report_style.css
@@ -47,6 +47,26 @@ body {
     white-space: nowrap;
 }
 
+.header-meet-name {
+    font-weight: bold;
+    font-size: 10pt;
+}
+
+.header-software {
+    text-align: right;
+    font-size: 8pt;
+}
+
+.header-meet-info {
+    font-size: 9pt;
+    margin-top: 1pt;
+}
+
+.header-sub-title {
+    font-size: 9pt;
+    margin-top: 1pt;
+}
+
 .header-right-col {
     text-align: right;
     vertical-align: top;
@@ -77,7 +97,6 @@ body {
     font-size: 9.5pt;
     padding: 3pt 4pt;
     border: 1pt solid #999;
-    text-transform: uppercase;
     text-align: left;
     width: 100%;
     break-after: avoid;
@@ -93,7 +112,6 @@ body {
     width: 100%;
     font-size: 7pt;
     color: #666;
-    text-transform: uppercase;
     border-bottom: 0.5pt solid #eee;
     padding: 2pt 0;
     font-weight: bold;
@@ -189,6 +207,10 @@ body {
     table-layout: fixed;
 }
 
+.div-relay-swimmers-row {
+    font-size: 8.5pt;
+}
+
 .div-swimmers-container {
     display: table-cell;
 }
@@ -223,6 +245,7 @@ body {
     line-height: 1.2;
     width: auto;
     vertical-align: bottom;
+    font-size: 8.5pt;
 }
 
 .relay-dq-line {

--- a/backend/src/mm_to_json/reporting/weasy_renderer.py
+++ b/backend/src/mm_to_json/reporting/weasy_renderer.py
@@ -3,6 +3,7 @@ import datetime
 import os
 from typing import Any
 
+import pytz
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 
@@ -28,10 +29,11 @@ class WeasyRenderer:
         render_data = copy.copy(data)
         render_data["css_content"] = css_content
         render_data["playwright"] = False
-        import pytz
 
         tz = pytz.timezone("America/Los_Angeles")
-        render_data["generation_time"] = datetime.datetime.now(tz).strftime("%I:%M %p %Y/%m/%d")
+        # Format like MM: "2:17 PM 5/29/2026"
+        # %-m and %-d remove leading zeros on Linux/Unix
+        render_data["generation_time"] = datetime.datetime.now(tz).strftime("%-I:%M %p %-m/%-d/%Y")
 
         return template.render(**render_data)
 

--- a/backend/tests/test_reporting_comprehensive.py
+++ b/backend/tests/test_reporting_comprehensive.py
@@ -1,8 +1,6 @@
 import unittest
-
 from mm_to_json.mm_to_json import MmToJsonConverter
 from mm_to_json.reporting.extractor import ReportDataExtractor
-
 
 class TestReportingComprehensive(unittest.TestCase):
     def setUp(self):
@@ -25,41 +23,44 @@ class TestReportingComprehensive(unittest.TestCase):
                     "event_no": 1,
                     "event_ptr": 1,
                     "ind_rel": "I",
-                    "event_gender": "M",
-                    "event_sex": "Boys",
+                    "event_gender": "X",
+                    "event_sex": "X",
                     "event_dist": 50,
                     "event_stroke": "A",
-                    "low_age": 11,
-                    "high_age": 12,
+                    "low_age": 9,
+                    "high_age": 10,
                     "num_finlanes": 6,
                     "event_rounds": 1,
                 }
             ],
             "athlete": [
-                {"ath_no": 1, "first_name": "Alice", "last_name": "Athlete", "ath_age": 11, "team_no": 1, "sex": "F"},
-                {"ath_no": 2, "first_name": "Bob", "last_name": "Swimmer", "ath_age": 12, "team_no": 1, "sex": "M"},
+                {"ath_no": 1, "first_name": "John", "last_name": "Doe", "ath_age": 10, "team_no": 1, "sex": "M"},
+                {"ath_no": 2, "first_name": "Jane", "last_name": "Smith", "ath_age": 9, "team_no": 2, "sex": "F"},
             ],
-            "team": [{"team_no": 1, "team_abbr": "TST", "team_name": "Test Team"}],
+            "team": [
+                {"team_no": 1, "team_abbr": "DP", "team_name": "Del Prado Stingrays"},
+                {"team_no": 2, "team_abbr": "FAST", "team_name": "FAST Dolphins"},
+            ],
             "entry": [
                 {
                     "event_ptr": 1,
                     "ath_no": 1,
                     "fin_heat": 1,
                     "fin_lane": 1,
-                    "convseed_time": 30.5,
-                    "fin_time": 29.5,
-                    "fin_stat": "",
-                    "fin_place": 1,
+                    "convseed_time": 31.2,
+                    "fin_time": 30.1,
+                    "fin_place": 2,
+                    "team_no": 1,
                 },
                 {
                     "event_ptr": 1,
                     "ath_no": 2,
                     "fin_heat": 1,
                     "fin_lane": 2,
-                    "convseed_time": 32.0,
-                    "fin_time": 31.0,
-                    "fin_stat": "",
-                    "fin_place": 2,
+                    "convseed_time": 30.5,
+                    "fin_time": 29.5,
+                    "fin_place": 1,
+                    "team_no": 2,
                 },
             ],
             "relay": [],
@@ -77,15 +78,14 @@ class TestReportingComprehensive(unittest.TestCase):
         self.assertIn("Event 1", group["header"])
         entries = group["sub_items"]
         self.assertEqual(len(entries), 2)
-        # Sorted by seed time: 30.5 should be first
-        self.assertEqual(entries[0]["time"], "30.500")
-        self.assertEqual(entries[1]["time"], "32.000")
+        # Sorted by seed time: 30.50 should be first
+        self.assertEqual(entries[0]["time"], "30.50")
+        self.assertEqual(entries[1]["time"], "31.20")
 
     def test_extract_timer_sheets_data(self):
         data = self.extractor.extract_timer_sheets_data()
         self.assertEqual(len(data["groups"]), 1)
         group = data["groups"][0]
-        # Timer sheets structure: group -> heats -> list of heat objects with header
         self.assertTrue(len(group["heats"]) > 0)
         heat = group["heats"][0]
         self.assertIn("Heat 1", heat["header"])
@@ -101,11 +101,10 @@ class TestReportingComprehensive(unittest.TestCase):
         entries = group["sub_items"]
         self.assertEqual(len(entries), 2)
         # Sorted by results time: 29.50 should be first
-        self.assertEqual(entries[0]["time"], "29.500")
+        self.assertEqual(entries[0]["time"], "29.50")
+        self.assertEqual(entries[1]["time"], "30.10")
         self.assertEqual(entries[0]["place"], "1")
-        self.assertEqual(entries[1]["time"], "31.000")
         self.assertEqual(entries[1]["place"], "2")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_reporting_comprehensive.py
+++ b/backend/tests/test_reporting_comprehensive.py
@@ -1,6 +1,8 @@
 import unittest
+
 from mm_to_json.mm_to_json import MmToJsonConverter
 from mm_to_json.reporting.extractor import ReportDataExtractor
+
 
 class TestReportingComprehensive(unittest.TestCase):
     def setUp(self):
@@ -105,6 +107,7 @@ class TestReportingComprehensive(unittest.TestCase):
         self.assertEqual(entries[1]["time"], "30.10")
         self.assertEqual(entries[0]["place"], "1")
         self.assertEqual(entries[1]["place"], "2")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_weasy_reporting.py
+++ b/backend/tests/test_weasy_reporting.py
@@ -91,7 +91,6 @@ def test_meet_program_dom_validation(fixture_path, tmp_path):
     # Assert headers
     assert "Tri-Valley Swim Lg. C" in soup.find(class_="header-meet-name").text
     assert soup.find(class_="header-meet-info").text == program_data["meet_name"]
-    assert "MM-Tools" in soup.find(class_="header-table").text
     # Assert event blocks
     event_blocks = soup.find_all(class_="event-block")
     assert len(event_blocks) == len(program_data["groups"])

--- a/backend/tests/test_weasy_reporting.py
+++ b/backend/tests/test_weasy_reporting.py
@@ -89,7 +89,8 @@ def test_meet_program_dom_validation(fixture_path, tmp_path):
     soup = BeautifulSoup(html_content, "html.parser")
 
     # Assert headers
-    assert soup.find(class_="header-meet-name").text == program_data["meet_name"]
+    assert "Tri-Valley Swim Lg. C" in soup.find(class_="header-meet-name").text
+    assert soup.find(class_="header-meet-info").text == program_data["meet_name"]
     assert "MM-Tools" in soup.find(class_="header-table").text
     # Assert event blocks
     event_blocks = soup.find_all(class_="event-block")

--- a/web-client/biome.json
+++ b/web-client/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",


### PR DESCRIPTION
This PR addresses all issues reported in #444 for Meet Manager parity:\n1. Uses 'short name' (Pref_name) for athletes.\n2. Formats all times to hundredths place.\n3. Includes ages (and gender prefix for Mixed) in relay swimmer names.\n4. Matches MM's 3-line header layout and font sizes.\n5. Updates posting reports to use correct gender filters.