### PR TITLE
Fix: Improve DQ/SCR mapping and include status in JSON

### DIFF
--- a/backend/scripts/compare_pdfs.py
+++ b/backend/scripts/compare_pdfs.py
@@ -1,0 +1,15 @@
+import pdfplumber
+import sys
+
+def analyze_pdf(path):
+    print(f"\n--- Analyzing {path} ---")
+    with pdfplumber.open(path) as pdf:
+        for i, page in enumerate(pdf.pages):
+            print(f"Page {i+1}:")
+            text = page.extract_text()
+            print(text[:1000] if text else "No text found")
+            if i >= 1: break # Only first 2 pages
+
+if __name__ == "__main__":
+    analyze_pdf(sys.argv[1])
+    analyze_pdf(sys.argv[2])

--- a/backend/scripts/extract_pdf_text.py
+++ b/backend/scripts/extract_pdf_text.py
@@ -1,0 +1,13 @@
+import pdfplumber
+import sys
+
+def extract_text(path, pages):
+    with pdfplumber.open(path) as pdf:
+        for p in pages:
+            if p <= len(pdf.pages):
+                page = pdf.pages[p-1]
+                print(f"--- Page {p} ---")
+                print(page.extract_text())
+
+if __name__ == "__main__":
+    extract_text(sys.argv[1], [7, 8])

--- a/backend/scripts/test_fixes_444.py
+++ b/backend/scripts/test_fixes_444.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import pandas as pd
+from typing import Any
+
+# Add paths
+base_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(base_dir, "../src"))
+
+from mm_to_json.mm_to_json import MmToJsonConverter
+
+def test_short_name():
+    mdb_path = "/Users/pfo/Developer/tmp/DP_at_FAST_before_meet.mdb"
+    print(f"Loading {mdb_path}...")
+    conv = MmToJsonConverter(mdb_path)
+    
+    # Check Gabriella (Ath_no 2068)
+    ath = conv.get_athlete_by_number(2068)
+    print(f"Athlete 2068: {ath['firstName']} {ath['lastName']}")
+    assert ath['firstName'] == "Ella"
+    
+    # Check Jaxon (Ath_no 2153)
+    ath = conv.get_athlete_by_number(2153)
+    print(f"Athlete 2153: {ath['firstName']} {ath['lastName']}")
+    assert ath['firstName'] == "Jax"
+    
+    print("Short name test passed!")
+
+def test_time_formatting():
+    mdb_path = "/Users/pfo/Developer/tmp/DP_at_FAST_before_meet.mdb"
+    conv = MmToJsonConverter(mdb_path)
+    
+    # Test num_to_string
+    assert conv.num_to_string(1.5732) == "1.57"
+    assert conv.num_to_string(117.320) == "117.32"
+    
+    # Test time_to_min_sec
+    assert conv.time_to_min_sec("117.320") == "1:57.32"
+    assert conv.time_to_min_sec("29.690") == "29.69"
+    
+    print("Time formatting test passed!")
+
+if __name__ == "__main__":
+    test_short_name()
+    test_time_formatting()

--- a/backend/scripts/verify_data.py
+++ b/backend/scripts/verify_data.py
@@ -1,0 +1,56 @@
+import sys
+import os
+import json
+import pdfplumber
+
+base_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(base_dir, "../src"))
+from mm_to_json.mm_to_json import MmToJsonConverter
+from mm_to_json.reporting.extractor import ReportDataExtractor
+
+def dump_pdf(path):
+    with pdfplumber.open(path) as pdf:
+        text = "\n".join([page.extract_text() for page in pdf.pages if page.extract_text()])
+        return text
+
+def test_report(mdb_path, team, gender, age):
+    conv = MmToJsonConverter(mdb_path)
+    extractor = ReportDataExtractor(conv)
+    return extractor.extract_meet_program_data(team_filter=team, gender_filter=gender, age_group_filter=age)
+
+if __name__ == "__main__":
+    mdb = "/Users/pfo/Developer/tmp/2026-05-30_DP_at_FAST_actual.mdb"
+    
+    # 1. Girls 9-10 Lineup
+    data = test_report(mdb, "DP", "Girls", "9-10")
+    print("--- Girls 9-10 Lineup (MMTools) ---")
+    for group in data["groups"]:
+        print(f"Header: {group['header']}")
+        for heat in group.get("heats", []):
+            print(f"  {heat['header']}")
+            for item in heat["sub_items"]:
+                if item.get("is_relay"):
+                    print(f"    L{item['lane']}: {item['name']} ({', '.join(item['swimmers'])})")
+                else:
+                    print(f"    L{item['lane']}: {item['name']}")
+
+    text = dump_pdf("/Users/pfo/Developer/tmp/girls_9-10_line_up.pdf")
+    print("\n--- Reference PDF ---")
+    print("\n".join(text.split("\n")[:20]))
+
+    # 2. Boys 9-10 Lineup
+    data = test_report(mdb, "DP", "Boys", "9-10")
+    print("\n--- Boys 9-10 Lineup (MMTools) ---")
+    for group in data["groups"]:
+        print(f"Header: {group['header']}")
+        for heat in group.get("heats", []):
+            print(f"  {heat['header']}")
+            for item in heat["sub_items"]:
+                if item.get("is_relay"):
+                    print(f"    L{item['lane']}: {item['name']} ({', '.join(item['swimmers'])})")
+                else:
+                    print(f"    L{item['lane']}: {item['name']}")
+
+    text = dump_pdf("/Users/pfo/Developer/tmp/boys_9-10_line_up.pdf")
+    print("\n--- Reference PDF ---")
+    print("\n".join(text.split("\n")[:20]))

--- a/backend/scripts/verify_data_2.py
+++ b/backend/scripts/verify_data_2.py
@@ -1,0 +1,17 @@
+import sys
+import os
+import json
+
+base_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(base_dir, "../src"))
+from mm_to_json.mm_to_json import MmToJsonConverter
+from mm_to_json.reporting.extractor import ReportDataExtractor
+
+if __name__ == "__main__":
+    mdb = "/Users/pfo/Developer/tmp/2026-05-30_DP_at_FAST_actual.mdb"
+    conv = MmToJsonConverter(mdb)
+    full_data = conv.convert()
+    for s in full_data["sessions"]:
+        for e in s["events"]:
+            if e["eventNum"] == 6:
+                print(e["gender"], e["isRelay"])

--- a/backend/scripts/verify_data_3.py
+++ b/backend/scripts/verify_data_3.py
@@ -1,0 +1,19 @@
+import sys
+import os
+import json
+
+base_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(base_dir, "../src"))
+from mm_to_json.mm_to_json import MmToJsonConverter
+from mm_to_json.reporting.extractor import ReportDataExtractor
+
+if __name__ == "__main__":
+    mdb = "/Users/pfo/Developer/tmp/2026-05-30_DP_at_FAST_actual.mdb"
+    conv = MmToJsonConverter(mdb)
+    extractor = ReportDataExtractor(conv)
+    data = extractor.extract_meet_program_data()
+    for group in data["groups"]:
+        if "Event 6" in group["header"]:
+            for heat in group["heats"]:
+                for item in heat["sub_items"]:
+                    print(item["swimmers"])

--- a/backend/scripts/verify_data_4.py
+++ b/backend/scripts/verify_data_4.py
@@ -1,0 +1,18 @@
+import sys
+import os
+import json
+
+base_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(base_dir, "../src"))
+from mm_to_json.mm_to_json import MmToJsonConverter
+from mm_to_json.reporting.extractor import ReportDataExtractor
+
+if __name__ == "__main__":
+    mdb = "/Users/pfo/Developer/tmp/2026-05-30_DP_at_FAST_actual.mdb"
+    conv = MmToJsonConverter(mdb)
+    full_data = conv.convert()
+    for s in full_data["sessions"]:
+        for e in s["events"]:
+            if e["eventNum"] == 6:
+                for entry in e["entries"]:
+                    print(entry["relayAthletes"])

--- a/backend/scripts/verify_data_5.py
+++ b/backend/scripts/verify_data_5.py
@@ -1,0 +1,52 @@
+import sys
+import os
+import json
+import pdfplumber
+
+base_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(base_dir, "../src"))
+from mm_to_json.mm_to_json import MmToJsonConverter
+from mm_to_json.reporting.extractor import ReportDataExtractor
+
+def dump_pdf(path):
+    with pdfplumber.open(path) as pdf:
+        text = "\n".join([page.extract_text() for page in pdf.pages if page.extract_text()])
+        return text
+
+def test_report(mdb_path, team, gender, age):
+    conv = MmToJsonConverter(mdb_path)
+    extractor = ReportDataExtractor(conv)
+    return extractor.extract_meet_program_data(team_filter=team, gender_filter=gender, age_group_filter=age)
+
+if __name__ == "__main__":
+    mdb = "/Users/pfo/Developer/tmp/2026-05-30_DP_at_FAST_actual.mdb"
+    
+    # Girls Posting
+    data = test_report(mdb, "DP", "Girls", "Open")
+    print("\n--- Girls Posting (MMTools) ---")
+    count = 0
+    for group in data["groups"]:
+        print(f"Header: {group['header']}")
+        for heat in group.get("heats", []):
+            for item in heat["sub_items"]:
+                if count < 10:
+                    if item.get("is_relay"):
+                        print(f"    L{item['lane']}: {item['name']} ({', '.join(item['swimmers'])})")
+                    else:
+                        print(f"    L{item['lane']}: {item['name']}")
+                    count += 1
+
+    # Boys Posting
+    data = test_report(mdb, "DP", "Boys", "Open")
+    print("\n--- Boys Posting (MMTools) ---")
+    count = 0
+    for group in data["groups"]:
+        print(f"Header: {group['header']}")
+        for heat in group.get("heats", []):
+            for item in heat["sub_items"]:
+                if count < 10:
+                    if item.get("is_relay"):
+                        print(f"    L{item['lane']}: {item['name']} ({', '.join(item['swimmers'])})")
+                    else:
+                        print(f"    L{item['lane']}: {item['name']}")
+                    count += 1

--- a/backend/scripts/verify_reports.py
+++ b/backend/scripts/verify_reports.py
@@ -1,0 +1,56 @@
+import sys
+import os
+import json
+import pdfplumber
+
+# Add paths
+base_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(base_dir, "../src"))
+
+from mm_to_json.mm_to_json import MmToJsonConverter
+from mm_to_json.reporting.extractor import ReportDataExtractor
+
+def dump_pdf(path):
+    with pdfplumber.open(path) as pdf:
+        text = "\n".join([page.extract_text() for page in pdf.pages if page.extract_text()])
+        return text
+
+def test_report(mdb_path, report_type, **kwargs):
+    conv = MmToJsonConverter(mdb_path)
+    extractor = ReportDataExtractor(conv)
+    if report_type == "meet_program":
+        return extractor.extract_meet_program_data(**kwargs)
+    return None
+
+if __name__ == "__main__":
+    mdb = "/Users/pfo/Developer/tmp/2026-05-30_DP_at_FAST_actual.mdb"
+    
+    pdfs = {
+        "Girls Posting": "/Users/pfo/Developer/tmp/girls_meet_program_for_posting.pdf",
+        "Boys Posting": "/Users/pfo/Developer/tmp/boys_meet_program_for_posting.pdf",
+        "Girls 9-10 Lineup": "/Users/pfo/Developer/tmp/girls_9-10_line_up.pdf",
+        "Boys 9-10 Lineup": "/Users/pfo/Developer/tmp/boys_9-10_line_up.pdf",
+    }
+    
+    print("--- MMTools Data Extraction ---")
+    conv = MmToJsonConverter(mdb)
+    extractor = ReportDataExtractor(conv)
+    
+    # Girls Posting
+    print("\nGirls Posting Data:")
+    data = extractor.extract_meet_program_data(gender_filter="Girls")
+    for group in data["groups"][:3]: # print first 3 groups
+        print(f"Header: {group['header']}")
+        if group.get("heats"):
+            for heat in group["heats"]:
+                print(f"  {heat['header']}")
+                for item in heat["sub_items"]:
+                    print(f"    {item}")
+        else:
+            for item in group.get("sub_items", []):
+                print(f"  {item}")
+
+    print("\n--- Reference PDF Text (Girls Posting) ---")
+    text = dump_pdf(pdfs["Girls Posting"])
+    print(text[:1000])
+

--- a/backend/scripts/verify_reports_2.py
+++ b/backend/scripts/verify_reports_2.py
@@ -1,0 +1,13 @@
+import sys
+import pdfplumber
+
+def dump_pdf(path):
+    with pdfplumber.open(path) as pdf:
+        text = "\n".join([page.extract_text() for page in pdf.pages if page.extract_text()])
+        return text
+
+if __name__ == "__main__":
+    text = dump_pdf("/Users/pfo/Developer/tmp/girls_meet_program_for_posting.pdf")
+    lines = text.split('\n')
+    for i, line in enumerate(lines[:100]):
+        print(line)

--- a/backend/scripts/verify_reports_3.py
+++ b/backend/scripts/verify_reports_3.py
@@ -1,0 +1,13 @@
+import sys
+import pdfplumber
+
+def dump_pdf(path):
+    with pdfplumber.open(path) as pdf:
+        text = "\n".join([page.extract_text() for page in pdf.pages if page.extract_text()])
+        return text
+
+if __name__ == "__main__":
+    text = dump_pdf("/Users/pfo/Developer/tmp/boys_meet_program_for_posting.pdf")
+    lines = text.split('\n')
+    for i, line in enumerate(lines[:100]):
+        print(line)

--- a/backend/src/mm_to_json/mm_to_json.py
+++ b/backend/src/mm_to_json/mm_to_json.py
@@ -794,6 +794,7 @@ class MmToJsonConverter:
                                 "psTime": entry_info["time"],
                                 "finalTime": entry_info["time"],
                                 "place": entry_info["place"],
+                                "status": entry_info["status"],
                                 "isRelay": False,
                                 "athleteId": ath_no,
                                 "teamId": athlete["teamId"],
@@ -887,6 +888,7 @@ class MmToJsonConverter:
                             "psTime": entry_info["time"],
                             "finalTime": entry_info["time"],
                             "place": entry_info["place"],
+                            "status": entry_info["status"],
                             "isRelay": True,
                             "athleteId": self._safe_int(row.get("relay_no")),
                             "relayLtr": relay_ltr,
@@ -923,6 +925,7 @@ class MmToJsonConverter:
         if round_ltr == "P":
             info["heat"] = pre_heat
             info["lane"] = pre_lane
+            info["status"] = pre_stat.upper().strip()
             info["time"] = self.time_to_string(pre_time, pre_stat)
         else:
             # Fallback to pre-heat/lane if fin-heat is zero (common in E2E mock data)
@@ -932,6 +935,7 @@ class MmToJsonConverter:
             # Use fin_time if available, otherwise pre_time if we fell back
             actual_time = fin_time if (fin_heat != 0 or not pre_heat) else pre_time
             actual_stat = fin_stat if (fin_heat != 0 or not pre_heat) else pre_stat
+            info["status"] = actual_stat.upper().strip()
             info["time"] = self.time_to_string(actual_time, actual_stat)
 
         if stroke != "Diving":
@@ -1038,7 +1042,7 @@ class MmToJsonConverter:
                         "lastName": last_name,
                         "name": f"{first_name} {last_name}",
                         "age": self._safe_int(row.get("ath_age") or row.get("age")),
-                        "athleteSex": self._get_val(row, "sex"),
+                        "athleteSex": self._get_val(row, "ath_sex") or self._get_val(row, "sex"),
                         "schoolYear": self._get_val(row, "schl_yr") or self._get_val(row, "class"),
                         "teamName": team_info["name"],
                         "teamCode": team_info["abbr"],
@@ -1103,13 +1107,14 @@ class MmToJsonConverter:
 
     def time_to_string(self, time_val, status):
         # logic from util.h
-        if status and status.upper() == "SCR":
+        s = str(status or "").upper().strip()
+        if s in ["SCR", "R"]:
             return "SCR"
-        if status and status.upper() == "DNS":
+        if s == "DNS":
             return "DNS"
-        if status and status.upper() == "DNF":
+        if s == "DNF":
             return "DNF"
-        if status and status.upper() == "DQ":
+        if s in ["DQ", "Q"]:
             return "DQ"
         try:
             val = float(time_val or 0.0)


### PR DESCRIPTION
This PR updates the MDB parser to correctly map 'Q' to 'DQ' and 'R' to 'SCR' in entry results. It also adds an explicit 'status' field to the entry JSON for better visibility into disqualifications and scratches.