### PR TITLE
Fix: Sanitize Logging of Sensitive Data

### DIFF
--- a/backend/src/auth_interceptor.py
+++ b/backend/src/auth_interceptor.py
@@ -38,8 +38,8 @@ class AuthInterceptor(grpc.ServerInterceptor):
                 # Verify the ID token
                 decoded_token = auth.verify_id_token(token)
                 uid = decoded_token["uid"]
-            except Exception as e:
-                logger.warning(f"Failed to verify ID token: {e}")
+            except Exception:
+                logger.warning("Failed to verify ID token (expired or invalid)")
                 # We could abort here, but let's just pass None and let the servicer decide
                 # or abort if it's a strictly protected method.
                 pass
@@ -104,8 +104,8 @@ class FirebaseAuthInterceptor(grpc.ServerInterceptor):
                 else:
                     decoded_token = auth.verify_id_token(token)
                     uid = decoded_token["uid"]
-            except Exception as e:
-                logger.warning(f"Invalid token: {e}")
+            except Exception:
+                logger.warning("Invalid token provided")
 
         handler = continuation(handler_call_details)
         if handler is None:

--- a/backend/src/mm_to_json/mm_to_json.py
+++ b/backend/src/mm_to_json/mm_to_json.py
@@ -28,7 +28,10 @@ class MmToJsonConverter:
             if not password:
                 password = os.environ.get("MM_DB_PASSWORD")
 
-            logger.info(f"Loading database: {mdb_path}")
+            # Sanitize path for logging
+            display_path = os.path.basename(mdb_path)
+            logger.info(f"Loading database: {display_path}")
+            logger.debug(f"DEBUG: Full MDB path: {mdb_path}")
 
             # Initialize Jackcess
             if mdb_writer:
@@ -203,9 +206,9 @@ class MmToJsonConverter:
                         logger.info("Detected Schema Type B (MTEVENT structure)")
 
                     rows: Any = self._read_table_jackcess(found_name)  # type: ignore
-                except Exception as e:
-                    logger.error(f"Failed to parse table {found_name}: {e}")
-                    logger.error("SKIPPING TABLE due to parse error.")
+                except Exception:
+                    logger.error(f"Failed to parse table {logical} (physical: {found_name})")
+                    logger.debug(f"Parse error details for {logical}", exc_info=True)
                     rows = None
 
                 df = pd.DataFrame(rows)
@@ -1329,7 +1332,7 @@ def main():
             elif args.report_type == "timers":
                 rg.generate_timer_sheets(out_path)
 
-            logger.info(f"Successfully generated report to {out_path}")
+            logger.info(f"Successfully generated report to {os.path.basename(out_path)}")
             return
 
         if args.raw:
@@ -1344,7 +1347,7 @@ def main():
         with open(out_path, "w") as f:
             json.dump(data, f, indent=4, default=json_serial)
 
-        logger.info(f"Successfully converted to {out_path}")
+        logger.info(f"Successfully converted to {os.path.basename(out_path)}")
 
     except Exception as e:
         logger.error(f"Error during conversion: {e}")

--- a/backend/src/mm_to_json/reporting/meet_event_writer.py
+++ b/backend/src/mm_to_json/reporting/meet_event_writer.py
@@ -246,5 +246,6 @@ class MeetEventWriter:
             zipf.writestr(hyv_filename, "\r\n".join(hyv_content) + "\r\n")
 
         import os
+
         logger.info(f"Generated meet events ZIP: {os.path.basename(output_zip_path)}")
         return output_zip_path

--- a/backend/src/mm_to_json/reporting/meet_event_writer.py
+++ b/backend/src/mm_to_json/reporting/meet_event_writer.py
@@ -245,5 +245,6 @@ class MeetEventWriter:
             zipf.writestr(ev3_filename, "\r\n".join(ev3_content) + "\r\n")
             zipf.writestr(hyv_filename, "\r\n".join(hyv_content) + "\r\n")
 
-        logger.info(f"Generated meet events ZIP: {output_zip_path}")
+        import os
+        logger.info(f"Generated meet events ZIP: {os.path.basename(output_zip_path)}")
         return output_zip_path

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -455,7 +455,9 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
             storage_exists = self.storage.exists(user_path)
 
             if is_e2e:
-                logging.debug(f"E2E: uid={self._mask_uid(uid)}, file={self._mask_path(user_path)}, exists={storage_exists}")
+                logging.debug(
+                    f"E2E: uid={self._mask_uid(uid)}, file={self._mask_path(user_path)}, exists={storage_exists}"
+                )
 
             # Check cache (Skip if E2E)
             if not is_e2e and uid in self._user_cache:
@@ -520,7 +522,9 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
                         oldest_uid, _ = self._user_cache.popitem(last=False)
                         logging.debug(f"DEBUG: Evicted {self._mask_uid(oldest_uid)} from user cache to save memory")
 
-                    logging.debug(f"DEBUG: Data loaded and cached for {self._mask_uid(uid)}/{filename} (mtime: {mtime})")
+                    logging.debug(
+                        f"DEBUG: Data loaded and cached for {self._mask_uid(uid)}/{filename} (mtime: {mtime})"
+                    )
                 except Exception as e:
                     logging.debug(f"DEBUG: Failed to update cache for {self._mask_uid(uid)}/{filename}: {e}")
 
@@ -590,7 +594,9 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
 
             # For LocalStorageProvider, print absolute path for debugging
             if hasattr(self.storage, "base_dir"):
-                logging.info(f"UploadDataset: saving to {self._mask_path(user_path)} (abs masked) for {self._mask_uid(uid)}")
+                logging.info(
+                    f"UploadDataset: saving to {self._mask_path(user_path)} (abs masked) for {self._mask_uid(uid)}"
+                )
             else:
                 logging.info(f"UploadDataset: saving to {self._mask_path(user_path)} for {self._mask_uid(uid)}")
 
@@ -743,7 +749,9 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
         data = self._get_table(cache, "meet")
 
         if not data and cache:
-            logging.warning(f"GetMeets: No 'meet' table found for {self._mask_uid(uid)}. Available tables: {list(cache.keys())}")
+            logging.warning(
+                f"GetMeets: No 'meet' table found for {self._mask_uid(uid)}. Available tables: {list(cache.keys())}"
+            )
 
         meets = []
         for item in data:
@@ -1142,7 +1150,9 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
 
         user_path = os.path.join("users", uid, filename)
         exists = self.storage.exists(user_path)
-        logging.info(f"SetActiveDataset: uid={self._mask_uid(uid)}, filename={filename}, user_path={self._mask_path(user_path)}, exists={exists}")
+        logging.info(
+            f"SetActiveDataset: uid={self._mask_uid(uid)}, filename={filename}, user_path={self._mask_path(user_path)}, exists={exists}"
+        )
 
         if not exists and not (filename == SOURCE_FILE and self.storage.exists(SOURCE_FILE)):
             logging.warning(f"SetActiveDataset: File {filename} NOT FOUND in user directory for {self._mask_uid(uid)}")
@@ -2153,7 +2163,9 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
         token = os.getenv("DATA_ACCESS_TOKEN") or "mmtools-default-secret-2024"
         uid = request.uid
 
-        logging.info(f"SyncDQs: Received request for UID: {self._mask_uid(uid)}, Payload length: {len(request.dqs_json)}")
+        logging.info(
+            f"SyncDQs: Received request for UID: {self._mask_uid(uid)}, Payload length: {len(request.dqs_json)}"
+        )
 
         if token and request.access_token == token:
             uid = request.uid
@@ -2258,7 +2270,9 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
                             # Force cache invalidation so Next.js/Web-Client sees the DQ
                             if uid in self._user_cache:
                                 del self._user_cache[uid]
-                            logging.info(f"Successfully updated {updated_count} entries in MDB for {self._mask_uid(uid)}")
+                            logging.info(
+                                f"Successfully updated {updated_count} entries in MDB for {self._mask_uid(uid)}"
+                            )
                         finally:
                             try:
                                 db.close()

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -412,7 +412,7 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
                         config = json.load(f)
                         return config
                 except Exception as e:
-                    logging.debug(f"DEBUG: Failed to load user config for {uid}: {e}")
+                    logging.debug(f"DEBUG: Failed to load user config for {self._mask_uid(uid)}: {e}")
                 finally:
                     if os.path.exists(tmp_path):
                         os.remove(tmp_path)
@@ -455,7 +455,7 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
             storage_exists = self.storage.exists(user_path)
 
             if is_e2e:
-                logging.info(f"E2E: uid={uid}, file={user_path}, exists={storage_exists}")
+                logging.debug(f"E2E: uid={self._mask_uid(uid)}, file={self._mask_path(user_path)}, exists={storage_exists}")
 
             # Check cache (Skip if E2E)
             if not is_e2e and uid in self._user_cache:
@@ -468,14 +468,14 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
                     try:
                         mtime = self.storage.get_last_modified(user_path)
                         if mtime == entry["mtime"]:
-                            logging.debug(f"DEBUG: Returning cached data for {uid}/{filename}")
+                            logging.debug(f"DEBUG: Returning cached data for {self._mask_uid(uid)}/{filename}")
                             return entry["data"], config
                         else:
                             logging.debug(
                                 f"DEBUG: Cache stale for {uid}/{filename} (mtime {mtime} != {entry['mtime']})"
                             )
                     except Exception as e:
-                        logging.debug(f"DEBUG: Cache check error for {uid}/{filename}: {e}")
+                        logging.debug(f"DEBUG: Cache check error for {self._mask_uid(uid)}/{filename}: {e}")
                         pass  # Force reload on error
 
             if not storage_exists:
@@ -491,7 +491,7 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
             else:
                 logging.debug(f"DEBUG: Found user file at {user_path}")
 
-            logging.debug(f"DEBUG: Loading data from {user_path}...")
+            logging.debug(f"DEBUG: Loading data from {self._mask_path(user_path)}...")
             with tempfile.NamedTemporaryFile(suffix=os.path.splitext(filename)[1], delete=False) as tmp:
                 tmp_path = tmp.name
                 tmp.close()  # Close to avoid locking
@@ -518,15 +518,15 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
                     # Evict oldest if limit exceeded
                     if len(self._user_cache) > MAX_CACHE_SIZE:
                         oldest_uid, _ = self._user_cache.popitem(last=False)
-                        logging.debug(f"DEBUG: Evicted {oldest_uid} from user cache to save memory")
+                        logging.debug(f"DEBUG: Evicted {self._mask_uid(oldest_uid)} from user cache to save memory")
 
-                    logging.debug(f"DEBUG: Data loaded and cached for {uid}/{filename} (mtime: {mtime})")
+                    logging.debug(f"DEBUG: Data loaded and cached for {self._mask_uid(uid)}/{filename} (mtime: {mtime})")
                 except Exception as e:
-                    logging.debug(f"DEBUG: Failed to update cache for {uid}/{filename}: {e}")
+                    logging.debug(f"DEBUG: Failed to update cache for {self._mask_uid(uid)}/{filename}: {e}")
 
                 return cache, config
             except Exception as e:
-                logging.error(f"DEBUG: Error loading data from {user_path}: {e}")
+                logging.error(f"DEBUG: Error loading data from {self._mask_path(user_path)}: {e}")
                 return {}, config
             finally:
                 if os.path.exists(tmp_path):
@@ -583,17 +583,16 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
             if not filename:
                 filename = "uploaded.mdb"
 
-            logging.info(f"UploadDataset: Final filename for {uid} is {filename}")
+            logging.info(f"UploadDataset: Final filename for {self._mask_uid(uid)} is {filename}")
             # Upload to storage provider
             user_path = os.path.join("users", uid, filename)
-            logging.info(f"UploadDataset: Targeting user_path={user_path} for {uid}")
+            logging.info(f"UploadDataset: Targeting user_path={self._mask_path(user_path)} for {self._mask_uid(uid)}")
 
             # For LocalStorageProvider, print absolute path for debugging
             if hasattr(self.storage, "base_dir"):
-                abs_user_path = os.path.abspath(os.path.join(self.storage.base_dir, user_path))
-                logging.info(f"UploadDataset: saving to {user_path} (abs: {abs_user_path}) for {uid}")
+                logging.info(f"UploadDataset: saving to {self._mask_path(user_path)} (abs masked) for {self._mask_uid(uid)}")
             else:
-                logging.info(f"UploadDataset: saving to {user_path} for {uid}")
+                logging.info(f"UploadDataset: saving to {self._mask_path(user_path)} for {self._mask_uid(uid)}")
 
             suffix = os.path.splitext(filename)[1]
             with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
@@ -612,7 +611,7 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
                 if os.path.exists(tmp_path):
                     os.remove(tmp_path)
 
-            logging.info(f"Saved uploaded file to {user_path}")
+            logging.info(f"Saved uploaded file to {self._mask_path(user_path)}")
 
             with self._lock:
                 # Update active dataset in config
@@ -623,7 +622,7 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
                 # INVALIDATE CACHE so next data load uses the new file
                 if uid in self._user_cache:
                     del self._user_cache[uid]
-                    logging.info(f"Invalidated cache for user {uid} due to UploadDataset")
+                    logging.info(f"Invalidated cache for user {self._mask_uid(uid)} due to UploadDataset")
 
                 # Invalidate cache to force reload of the new dataset
                 if uid in self._user_cache:
@@ -718,6 +717,24 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
                     return d[actual_key]
         return default
 
+    def _mask_path(self, path: str) -> str:
+        """Masks sensitive parts of a path for safe logging."""
+        if not path:
+            return ""
+        if path.startswith("users/"):
+            parts = path.split("/")
+            if len(parts) > 1:
+                uid = parts[1]
+                masked_uid = self._mask_uid(uid)
+                return "/".join(["users", masked_uid] + parts[2:])
+        return path
+
+    def _mask_uid(self, uid: str) -> str:
+        """Masks a UID for safe logging."""
+        if not uid or len(uid) < 8:
+            return "***"
+        return f"{uid[:4]}...{uid[-4:]}"
+
     def GetMeets(self, request, context):
         request = request or pb2.GetMeetsRequest()
         cache, _ = self._load_user_data(context)
@@ -726,7 +743,7 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
         data = self._get_table(cache, "meet")
 
         if not data and cache:
-            logging.warning(f"GetMeets: No 'meet' table found for {uid}. Available tables: {list(cache.keys())}")
+            logging.warning(f"GetMeets: No 'meet' table found for {self._mask_uid(uid)}. Available tables: {list(cache.keys())}")
 
         meets = []
         for item in data:
@@ -757,7 +774,7 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
         data = self._get_table(cache, "team")
         athletes = self._get_table(cache, "athlete")
 
-        logging.debug(f"DEBUG: GetTeams for user {uid}, found {len(data)} teams")
+        logging.debug(f"DEBUG: GetTeams for user {self._mask_uid(uid)}, found {len(data)} teams")
 
         # Count athletes per team
         ath_counts: dict[int, int] = {}
@@ -1061,14 +1078,13 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
         config = self._load_user_config(context)
         active_file = config.get("active_dataset", SOURCE_FILE)
 
-        logging.info(f"ListDatasets: uid={uid}, active_file={active_file}")
+        logging.info(f"ListDatasets: uid={self._mask_uid(uid)}, active_file={active_file}")
         datasets = []
         try:
             # List files from users/[uid]/
             user_prefix = os.path.join("users", uid)
             if hasattr(self.storage, "_get_full_path"):
-                full_path = self.storage._get_full_path(user_prefix)
-                logging.info(f"ListDatasets: Checking local path: {full_path}")
+                logging.info("ListDatasets: Checking local path")
 
             # Retry loop for eventual consistency in CI environments            files = []
             for attempt in range(5):
@@ -1076,10 +1092,10 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
                 if files:
                     break
                 if attempt < 4:
-                    logging.info(f"ListDatasets: No files found for {uid}, retrying in 2s...")
+                    logging.info(f"ListDatasets: No files found for {self._mask_uid(uid)}, retrying in 2s...")
                     time.sleep(2)
 
-            logging.info(f"ListDatasets: Found {len(files)} files in {user_prefix}: {files}")
+            logging.info(f"ListDatasets: Found {len(files)} files in {self._mask_path(user_prefix)}: {files}")
 
             # Also include default Sample_Data.json if it exists and user has no files?
             # For simplicity, let's just list user's files
@@ -1126,16 +1142,16 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
 
         user_path = os.path.join("users", uid, filename)
         exists = self.storage.exists(user_path)
-        logging.info(f"SetActiveDataset: uid={uid}, filename={filename}, user_path={user_path}, exists={exists}")
+        logging.info(f"SetActiveDataset: uid={self._mask_uid(uid)}, filename={filename}, user_path={self._mask_path(user_path)}, exists={exists}")
 
         if not exists and not (filename == SOURCE_FILE and self.storage.exists(SOURCE_FILE)):
-            logging.warning(f"SetActiveDataset: File {filename} NOT FOUND in user directory for {uid}")
+            logging.warning(f"SetActiveDataset: File {filename} NOT FOUND in user directory for {self._mask_uid(uid)}")
             context.set_code(grpc.StatusCode.NOT_FOUND)
             context.set_details(f"File {filename} not found.")
             return pb2.SetActiveDatasetResponse()
 
         with self._lock:
-            logging.info(f"Switching user {uid} dataset to {filename}...")
+            logging.info(f"Switching user {self._mask_uid(uid)} dataset to {filename}...")
             # Update config
             config = self._load_user_config(context)
             config["active_dataset"] = filename
@@ -1152,7 +1168,7 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
             # FORCE SYNCHRONOUS EXTRACTION:
             # This ensures the database is fully populated before returning to the caller.
             # Critical for E2E/CI reliability.
-            logging.info(f"SetActiveDataset: Forcing synchronous extraction for {uid}/{filename}...")
+            logging.debug(f"SetActiveDataset: Forcing synchronous extraction for {self._mask_uid(uid)}/{filename}...")
             try:
                 self._load_user_data(context)
                 # Clear cache AGAIN after extraction if it's an E2E-like environment
@@ -1161,9 +1177,9 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
                 if os.getenv("IS_E2E") == "true" or "x-e2e-uid" in metadata or "x-user-id" in metadata:
                     if uid in self._user_cache:
                         del self._user_cache[uid]
-                logging.info(f"SetActiveDataset: Extraction complete for {uid}/{filename}")
+                logging.debug(f"SetActiveDataset: Extraction complete for {self._mask_uid(uid)}/{filename}")
             except Exception as e:
-                logging.error(f"SetActiveDataset: Extraction failed for {uid}/{filename}: {e}")
+                logging.error(f"SetActiveDataset: Extraction failed for {self._mask_uid(uid)}/{filename}: {e}")
                 # Reset config if extraction failed to prevent a broken active dataset
                 config["active_dataset"] = SOURCE_FILE
                 self._save_user_config(context, config)
@@ -2137,11 +2153,11 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
         token = os.getenv("DATA_ACCESS_TOKEN") or "mmtools-default-secret-2024"
         uid = request.uid
 
-        logging.info(f"SyncDQs: Received request for UID: {uid}, Payload length: {len(request.dqs_json)}")
+        logging.info(f"SyncDQs: Received request for UID: {self._mask_uid(uid)}, Payload length: {len(request.dqs_json)}")
 
         if token and request.access_token == token:
             uid = request.uid
-            logging.info(f"SyncDQs: Authenticated via system token for user {uid}")
+            logging.info(f"SyncDQs: Authenticated via system token for user {self._mask_uid(uid)}")
         else:
             uid = self._check_auth(context)
 
@@ -2171,7 +2187,7 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
             if active_filename and active_filename.lower().endswith(".mdb"):
                 dataset_path = os.path.join("users", uid, active_filename)
                 if self.storage.exists(dataset_path):
-                    logging.info(f"Syncing DQs to MDB: {dataset_path} for user {uid}")
+                    logging.info(f"Syncing DQs to MDB: {self._mask_path(dataset_path)} for user {self._mask_uid(uid)}")
 
                     # Download MDB to local temp for writing
                     with tempfile.NamedTemporaryFile(suffix=".mdb", delete=False) as tmp_mdb:
@@ -2242,7 +2258,7 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
                             # Force cache invalidation so Next.js/Web-Client sees the DQ
                             if uid in self._user_cache:
                                 del self._user_cache[uid]
-                            logging.info(f"Successfully updated {updated_count} entries in MDB for {uid}")
+                            logging.info(f"Successfully updated {updated_count} entries in MDB for {self._mask_uid(uid)}")
                         finally:
                             try:
                                 db.close()
@@ -2252,7 +2268,7 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
                         if os.path.exists(tmp_mdb_path):
                             os.remove(tmp_mdb_path)
 
-            logging.info(f"Synced {len(dqs)} DQs for user {uid}")
+            logging.info(f"Synced {len(dqs)} DQs for user {self._mask_uid(uid)}")
             return pb2.SyncDQsResponse(success=True, message=f"Synced {len(dqs)} items")
         except Exception as e:
             logging.error(f"Sync failed: {e}")

--- a/backend/src/storage_provider.py
+++ b/backend/src/storage_provider.py
@@ -7,6 +7,16 @@ logger = logging.getLogger(__name__)
 
 
 class StorageProvider(ABC):
+    def _sanitize_path(self, path: str) -> str:
+        """Masks sensitive parts of the path (e.g. UIDs)."""
+        if path.startswith("users/"):
+            parts = path.split("/")
+            if len(parts) > 1:
+                uid = parts[1]
+                masked_uid = f"{uid[:4]}...{uid[-4:]}" if len(uid) > 8 else "***"
+                return "/".join(["users", masked_uid] + parts[2:])
+        return path
+
     @abstractmethod
     def list_files(self, prefix: str) -> list[str]:
         pass
@@ -50,16 +60,6 @@ class LocalStorageProvider(StorageProvider):
             raise PermissionError(f"Path traversal attempt detected: {path}")
 
         return full_path
-
-    def _sanitize_path(self, path: str) -> str:
-        """Masks sensitive parts of the path (e.g. UIDs)."""
-        if path.startswith("users/"):
-            parts = path.split("/")
-            if len(parts) > 1:
-                uid = parts[1]
-                masked_uid = f"{uid[:4]}...{uid[-4:]}" if len(uid) > 8 else "***"
-                return "/".join(["users", masked_uid] + parts[2:])
-        return path
 
     def list_files(self, prefix: str) -> list[str]:
         full_prefix_path = self._get_full_path(prefix)

--- a/backend/src/storage_provider.py
+++ b/backend/src/storage_provider.py
@@ -51,11 +51,21 @@ class LocalStorageProvider(StorageProvider):
 
         return full_path
 
+    def _sanitize_path(self, path: str) -> str:
+        """Masks sensitive parts of the path (e.g. UIDs)."""
+        if path.startswith("users/"):
+            parts = path.split("/")
+            if len(parts) > 1:
+                uid = parts[1]
+                masked_uid = f"{uid[:4]}...{uid[-4:]}" if len(uid) > 8 else "***"
+                return "/".join(["users", masked_uid] + parts[2:])
+        return path
+
     def list_files(self, prefix: str) -> list[str]:
         full_prefix_path = self._get_full_path(prefix)
-        logger.info(f"LocalStorageProvider: list_files(prefix={prefix}) -> {full_prefix_path}")
+        logger.debug(f"LocalStorageProvider: list_files(prefix={self._sanitize_path(prefix)})")
         if not os.path.exists(full_prefix_path):
-            logger.info(f"LocalStorageProvider: path does not exist: {full_prefix_path}")
+            logger.debug(f"LocalStorageProvider: path does not exist: {self._sanitize_path(prefix)}")
             return []
 
         files = []
@@ -63,32 +73,32 @@ class LocalStorageProvider(StorageProvider):
             for filename in filenames:
                 rel_path = os.path.relpath(os.path.join(root, filename), self.base_dir)
                 files.append(rel_path)
-        logger.info(f"LocalStorageProvider: found {len(files)} files: {files}")
+        logger.debug(f"LocalStorageProvider: found {len(files)} files")
         return files
 
     def upload_file(self, local_path: str, remote_path: str) -> None:
         dest = self._get_full_path(remote_path)
-        logger.info(f"LocalStorageProvider: upload_file(local={local_path}, remote={remote_path}) -> dest={dest}")
+        logger.debug(f"LocalStorageProvider: upload_file to {self._sanitize_path(remote_path)}")
         os.makedirs(os.path.dirname(dest), exist_ok=True)
         shutil.copy2(local_path, dest)
-        logger.info(f"LocalStorageProvider: successfully saved to {dest}")
+        logger.debug(f"LocalStorageProvider: successfully saved to {self._sanitize_path(remote_path)}")
 
     def download_file(self, remote_path: str, local_path: str) -> None:
         src = self._get_full_path(remote_path)
-        logger.info(f"LocalStorageProvider: download_file(remote={remote_path}, local={local_path}) -> src={src}")
+        logger.debug(f"LocalStorageProvider: download_file {self._sanitize_path(remote_path)}")
         os.makedirs(os.path.dirname(local_path), exist_ok=True)
         shutil.copy2(src, local_path)
 
     def delete_file(self, remote_path: str) -> None:
         path = self._get_full_path(remote_path)
-        logger.info(f"LocalStorageProvider: delete_file(remote={remote_path}) -> {path}")
+        logger.debug(f"LocalStorageProvider: delete_file {self._sanitize_path(remote_path)}")
         if os.path.exists(path):
             os.remove(path)
 
     def exists(self, remote_path: str) -> bool:
         path = self._get_full_path(remote_path)
         res = os.path.exists(path)
-        logger.info(f"LocalStorageProvider: exists(remote={remote_path}) -> {path}: {res}")
+        logger.debug(f"LocalStorageProvider: exists({self._sanitize_path(remote_path)}) -> {res}")
         return res
 
     def get_last_modified(self, remote_path: str) -> float:
@@ -179,12 +189,13 @@ class GCSStorageProvider(StorageProvider):
                 credentials=self.client._credentials,
             )
 
-            logger.info(f"Generated signed URL for {remote_path} (SA: {self.service_account_email})")
+            logger.debug(f"Generated signed URL for {self._sanitize_path(remote_path)} (SA: {self.service_account_email})")
             return url
-        except Exception as e:
+        except Exception:
             # Fallback to relative API path that the frontend can handle
             # The frontend knows how to append its own origin and token
-            logger.warning(f"Failed to generate signed URL for {remote_path}: {e}")
+            logger.warning(f"Failed to generate signed URL for {self._sanitize_path(remote_path)} (Check IAM roles)")
+
             import urllib.parse
 
             safe_path = urllib.parse.quote(remote_path)

--- a/backend/src/storage_provider.py
+++ b/backend/src/storage_provider.py
@@ -189,7 +189,9 @@ class GCSStorageProvider(StorageProvider):
                 credentials=self.client._credentials,
             )
 
-            logger.debug(f"Generated signed URL for {self._sanitize_path(remote_path)} (SA: {self.service_account_email})")
+            logger.debug(
+                f"Generated signed URL for {self._sanitize_path(remote_path)} (SA: {self.service_account_email})"
+            )
             return url
         except Exception:
             # Fallback to relative API path that the frontend can handle

--- a/web-client/app/actions.ts
+++ b/web-client/app/actions.ts
@@ -14,7 +14,9 @@ async function getAuthMetadata() {
 	// Fallback for local development or E2E bypass
 	if (process.env.NEXT_PUBLIC_E2E_AUTH_BYPASS === "true" && !userId) {
 		userId = "e2e-bypass-user";
-		console.log(`DEBUG: E2E Auth Bypass triggered for user: ${userId}`);
+		if (process.env.NODE_ENV !== "production") {
+			console.log(`DEBUG: E2E Auth Bypass triggered for user: ${userId}`);
+		}
 	}
 
 	if (!userId) {

--- a/web-client/app/api/submit-dq/route.ts
+++ b/web-client/app/api/submit-dq/route.ts
@@ -20,9 +20,11 @@ export async function POST(request: NextRequest) {
 		const paramUid = searchParams.get("uid");
 		const userId = headerUserId || paramUid || "e2e-bypass-user";
 
-		console.log(
-			`API SUBMIT-DQ: Received request. UserID: ${userId}, Token Provided: ${token ? "YES" : "NO"}`,
-		);
+		if (process.env.NODE_ENV !== "production") {
+			console.log(
+				`API SUBMIT-DQ: Received request. UserID: ${userId}, Token Provided: ${token ? "YES" : "NO"}`,
+			);
+		}
 
 		// Basic security check
 		const configuredToken = process.env.DATA_ACCESS_TOKEN;

--- a/web-client/biome.json
+++ b/web-client/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/web-client/biome.json
+++ b/web-client/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/web-client/components/dataset-manager.tsx
+++ b/web-client/components/dataset-manager.tsx
@@ -115,11 +115,15 @@ export function DatasetManager() {
 	const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
 		const file = e.target.files?.[0];
 		if (!file) {
-			console.log("E2E DEBUG: No file selected in input");
+			if (process.env.NODE_ENV !== "production") {
+				console.log("E2E DEBUG: No file selected in input");
+			}
 			return;
 		}
 
-		console.log(`E2E DEBUG: Uploading file: ${file.name}, size: ${file.size}`);
+		if (process.env.NODE_ENV !== "production") {
+			console.log(`E2E DEBUG: Uploading file: ${file.name}, size: ${file.size}`);
+		}
 		setIsUploading(true);
 		const formData = new FormData();
 		formData.append("file", file);
@@ -127,19 +131,27 @@ export function DatasetManager() {
 		try {
 			// Manual upload implementation using a server action
 			const { uploadDataset } = await import("@/app/actions");
-			console.log("E2E DEBUG: Calling uploadDataset server action...");
+			if (process.env.NODE_ENV !== "production") {
+				console.log("E2E DEBUG: Calling uploadDataset server action...");
+			}
 			const res = await uploadDataset(formData);
 
 			if (res.success) {
-				console.log("E2E DEBUG: Upload success!");
+				if (process.env.NODE_ENV !== "production") {
+					console.log("E2E DEBUG: Upload success!");
+				}
 				toast.success("Dataset uploaded successfully");
 				await fetchDatasets();
 			} else {
-				console.log(`E2E DEBUG: Upload failed: ${res.message}`);
+				if (process.env.NODE_ENV !== "production") {
+					console.log(`E2E DEBUG: Upload failed: ${res.message}`);
+				}
 				toast.error(res.message || "Upload failed");
 			}
 		} catch (error) {
-			console.error("E2E DEBUG: Upload error:", error);
+			if (process.env.NODE_ENV !== "production") {
+				console.error("E2E DEBUG: Upload error:", error);
+			}
 			toast.error("An error occurred during upload");
 		} finally {
 			setIsUploading(false);

--- a/web-client/components/dataset-manager.tsx
+++ b/web-client/components/dataset-manager.tsx
@@ -122,7 +122,9 @@ export function DatasetManager() {
 		}
 
 		if (process.env.NODE_ENV !== "production") {
-			console.log(`E2E DEBUG: Uploading file: ${file.name}, size: ${file.size}`);
+			console.log(
+				`E2E DEBUG: Uploading file: ${file.name}, size: ${file.size}`,
+			);
 		}
 		setIsUploading(true);
 		const formData = new FormData();

--- a/web-client/hooks/use-auth.tsx
+++ b/web-client/hooks/use-auth.tsx
@@ -55,18 +55,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 				pathname.startsWith("/api/data");
 
 			if (!isPublicPath) {
-				console.log(
-					`[AuthProvider] Redirecting unauthenticated user from ${pathname} to /login`,
-				);
+				if (process.env.NODE_ENV !== "production") {
+					console.log(
+						`[AuthProvider] Redirecting unauthenticated user from ${pathname} to /login`,
+					);
+				}
 				router.push(`/login?returnUrl=${encodeURIComponent(pathname)}`);
 			}
 		}
 	}, [user, loading, pathname, router, isAuthDisabled]);
 
 	useEffect(() => {
-		console.log(
-			`[AuthProvider] Init: isAuthDisabled=${isAuthDisabled}, bypass=${process.env.NEXT_PUBLIC_E2E_AUTH_BYPASS}`,
-		);
+		if (process.env.NODE_ENV !== "production") {
+			console.log(
+				`[AuthProvider] Init: isAuthDisabled=${isAuthDisabled}, bypass=${process.env.NEXT_PUBLIC_E2E_AUTH_BYPASS}`,
+			);
+		}
 	}, [isAuthDisabled]);
 
 	useEffect(() => {
@@ -79,7 +83,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 			const storedUid = Cookies.get("x-user-id");
 			const mockUid = storedUid || "e2e-default-user";
 
-			console.log(`[AuthProvider] E2E Bypass Active. UID: ${mockUid}`);
+			if (process.env.NODE_ENV !== "production") {
+				console.log(`[AuthProvider] E2E Bypass Active. UID: ${mockUid}`);
+			}
 
 			const mockUser = {
 				uid: mockUid,

--- a/web-client/lib/mm-client.ts
+++ b/web-client/lib/mm-client.ts
@@ -27,13 +27,17 @@ if (typeof window === "undefined") {
 	rawHost = `localhost:${port}`;
 }
 
-console.log(
-	`E2E DEBUG: mm-client connecting to rawHost: ${rawHost} (Mode: ${typeof window === "undefined" ? "Server" : "Client"})`,
-);
+if (process.env.NODE_ENV !== "production") {
+	console.log(
+		`E2E DEBUG: mm-client connecting to rawHost: ${rawHost} (Mode: ${typeof window === "undefined" ? "Server" : "Client"})`,
+	);
+}
 
 // Strip protocol if present (e.g. from http://backend:8080)
 const host = rawHost.replace(/^https?:\/\//, "");
-console.log(`E2E DEBUG: mm-client channel host: ${host}`);
+if (process.env.NODE_ENV !== "production") {
+	console.log(`E2E DEBUG: mm-client channel host: ${host}`);
+}
 
 // Create a middleware to add the token and x-user-id to every request
 const authMiddleware = async function* (call: any, options: any) {

--- a/web-client/middleware.ts
+++ b/web-client/middleware.ts
@@ -9,9 +9,11 @@ export function middleware(request: NextRequest) {
 		process.env.NEXT_PUBLIC_AUTH_DISABLED === "true" ||
 		process.env.NEXT_PUBLIC_E2E_AUTH_BYPASS === "true";
 
-	console.log(
-		`[Middleware] Path: ${pathname}, AuthDisabled: ${isAuthDisabled}, E2EBypass: ${process.env.NEXT_PUBLIC_E2E_AUTH_BYPASS}`,
-	);
+	if (process.env.NODE_ENV !== "production") {
+		console.log(
+			`[Middleware] Path: ${pathname}, AuthDisabled: ${isAuthDisabled}, E2EBypass: ${process.env.NEXT_PUBLIC_E2E_AUTH_BYPASS}`,
+		);
+	}
 
 	if (isAuthDisabled) {
 		return NextResponse.next();


### PR DESCRIPTION
This PR addresses security concerns regarding the logging of sensitive data (PII, User IDs, and absolute paths) in both the backend and web client.\n\n### Changes:\n- **Backend (`server.py`)**: Introduced `_mask_uid` and `_mask_path` helpers to sanitize identifiers and paths in all production logs. Changed verbose file-system logs to `DEBUG` level.\n- **Backend (`storage_provider.py`)**: Sanitized all file operation logs in both `LocalStorageProvider` and `GCSStorageProvider`. Masked the UID portion of paths.\n- **Backend (`mm_to_json.py`)**: Sanitized database path logs and table parsing error messages to avoid leaking row data.\n- **Backend (`auth_interceptor.py`)**: Redacted raw exception objects from token verification logs to prevent metadata leakage.\n- **Web Client**: Gated all `console.log` statements in `middleware.ts`, `actions.ts`, and `use-auth.tsx` to only occur in non-production environments.\n- **Web Client (`dataset-manager.tsx`)**: Gated E2E debug logs to non-production only.\n\nThese changes ensure that production log streams are clean of sensitive user data while maintaining sufficient information for auditing and debugging.