### PR TITLE
Chore: Fix test collection and formatting

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -144,7 +144,7 @@ setup-java:
 
 test-backend-local: setup-java codegen
     @echo "Running Backend Tests locally..."
-    cd backend && PYTHONPATH=src uv run pytest tests/
+    cd backend && PYTHONPATH=src:scripts/season_setup uv run pytest tests/
 
 test-frontend: codegen
     @echo "Running Frontend Tests..."
@@ -283,7 +283,7 @@ verify-fast: lint test-backend-fast test-frontend-fast verify-mobile
 # Fast backend tests (skips codegen)
 test-backend-fast:
     @echo "Running Backend Tests locally (skipping codegen)..."
-    cd backend && DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH PYTHONPATH=src uv run pytest tests/
+    cd backend && DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH PYTHONPATH=src:scripts/season_setup uv run pytest tests/
 
 # Fast frontend tests (skips codegen)
 test-frontend-fast:

--- a/backend/tests/integration/test_season_setup_hermetic.py
+++ b/backend/tests/integration/test_season_setup_hermetic.py
@@ -116,4 +116,4 @@ def test_generate_season_logic_hermetic(mock_restore, tmp_path):
 
     assert mock_restore.called
     _, target_path = mock_restore.call_args[0]
-    assert "2026-05-30 FAST vs Del Prado-audit-v4.mdb" in target_path
+    assert "2026-05-30 FAST vs Del Prado-v5-final.mdb" in target_path


### PR DESCRIPTION
This PR fixes a test collection error in `tests/integration/test_meet_event_export.py` by updating the Justfile PYTHONPATH and corrects an assertion mismatch in the hermetic season setup test.