### PR TITLE
Feat: Medley Relay before Free Relay

### DIFF
--- a/attendance-tracker/populate_sheets.py
+++ b/attendance-tracker/populate_sheets.py
@@ -198,8 +198,8 @@ def apply_formatting(
         )
 
         # Rule 2: Relay Scratch Warning (Darker Red/Orange)
-        # Highlight entire row if Scratch is TRUE AND (Free Relay is X OR Medley Relay is X)
-        # Scratch: F (Col 6), Free Relay: G (Col 7), Medley Relay: H (Col 8)
+        # Highlight entire row if Scratch is TRUE AND (Medley Relay is X OR Free Relay is X)
+        # Scratch: F (Col 6), Medley Relay: G (Col 7), Free Relay: H (Col 8)
         # Formula: =AND($F2, OR($G2="X", $H2="X"))
         requests.append(
             {
@@ -255,8 +255,8 @@ def populate() -> None:
         "Last Name",
         "Present",
         "Scratch",
-        "Free Relay",
         "Medley Relay",
+        "Free Relay",
         "Free",
         "Back",
         "Breast",
@@ -288,8 +288,8 @@ def populate() -> None:
         row[3] = s.get("Last Name", "")
         row[4] = False  # Present
         row[5] = False  # Scratch
-        row[6] = s.get("Free Relay", "")
-        row[7] = s.get("Medley Relay", "")
+        row[6] = s.get("Medley Relay", "")
+        row[7] = s.get("Free Relay", "")
         row[8] = s.get("Free", "")
         row[9] = s.get("Back", "")
         row[10] = s.get("Breast", "")

--- a/attendance-tracker/tests/verify_spreadsheet.py
+++ b/attendance-tracker/tests/verify_spreadsheet.py
@@ -14,7 +14,7 @@ Spreadsheet ID: {spreadsheet_id}
 Verify the following:
 1. 'Main' Tab:
    a) Tab Position: Confirm 'Main' tab is located AFTER the 6 Age Group tabs (position index 6).
-   b) Headers (A1:Q1) are exactly: "Age Group", "Gender", "Preferred Name", "Last Name", "Present", "Scratch", "Free Relay", "Medley Relay", "Free", "Back", "Breast", "Fly", "IM", "ID", "First Name", "Age", "Team".
+   b) Headers (A1:Q1) are exactly: "Age Group", "Gender", "Preferred Name", "Last Name", "Present", "Scratch", "Medley Relay", "Free Relay", "Free", "Back", "Breast", "Fly", "IM", "ID", "First Name", "Age", "Team".
    c) Sorting: Verify data is sorted by Age Group, then Gender, then Preferred Name (check first 5 rows).
    d) Conditional Formatting: 
       - Rule 1: Highlights E and F if both are TRUE (=AND($E2,$F2)).


### PR DESCRIPTION
This PR swaps the order of 'Medley Relay' and 'Free Relay' columns to prioritize the first event of the meet.

Key Changes:
- **Column Order**: 'Medley Relay' now precedes 'Free Relay' in all tabs.
- **Audit**: Verified end-to-end with sub-agent audit.