### PR TITLE
fix(reporting): optimize page density and margins for lane timer sheets

### DIFF
--- a/backend/src/mm_to_json/reporting/extractor.py
+++ b/backend/src/mm_to_json/reporting/extractor.py
@@ -898,11 +898,11 @@ class ReportDataExtractor:
                             item["swimmers"] = []
                         lane_entries.append(item)
 
-            # 4. Group into pages of rows
             current_page_rows: list[dict[str, Any]] = []
             current_event_num = None
             distinct_events_count = 0
             page_num = 1
+            current_page_height = 0
 
             def finish_page_v3(l_num, p_rows, p_num):
                 if p_rows:
@@ -915,11 +915,21 @@ class ReportDataExtractor:
             for item in lane_entries:
                 item_event_num = item["event_num"]
                 needs_header = item_event_num != current_event_num
-                rows_to_add = 2 if needs_header else 1
+
+                # Height calculation
+                height_to_add = 0
+                if needs_header:
+                    height_to_add += 18
+                if item.get("is_blank"):
+                    height_to_add += 18
+                elif item.get("is_relay"):
+                    height_to_add += 42
+                else:
+                    height_to_add += 30
 
                 # Check page break conditions
                 should_break = False
-                if len(current_page_rows) + rows_to_add > 12:
+                if current_page_height + height_to_add > 600:
                     should_break = True
                 elif break_every_six_events and needs_header and distinct_events_count >= 6:
                     should_break = True
@@ -933,7 +943,16 @@ class ReportDataExtractor:
                     current_page_rows, page_num = finish_page_v3(lane_num, current_page_rows, page_num)
                     distinct_events_count = 0
                     current_event_num = None
+                    current_page_height = 0
                     needs_header = True
+                    # Re-calculate height to add as header is now required
+                    height_to_add = 18
+                    if item.get("is_blank"):
+                        height_to_add += 18
+                    elif item.get("is_relay"):
+                        height_to_add += 42
+                    else:
+                        height_to_add += 30
 
                 if needs_header:
                     current_page_rows.append(
@@ -947,6 +966,7 @@ class ReportDataExtractor:
                     current_event_num = item_event_num
 
                 current_page_rows.append({"type": "swimmer", "item": item})
+                current_page_height += height_to_add
 
             # Final page for this lane
             current_page_rows, page_num = finish_page_v3(lane_num, current_page_rows, page_num)

--- a/backend/src/mm_to_json/reporting/templates/timer_sheets.j2
+++ b/backend/src/mm_to_json/reporting/templates/timer_sheets.j2
@@ -4,6 +4,15 @@
 {% block container_class %}timer-sheet-content{% endblock %}
 
 {% block extra_css %}
+    @page {
+        margin: 0.35in;
+        margin-top: 0.85in;
+        margin-bottom: 0.35in;
+    }
+    #header {
+        padding-top: 0.15in !important;
+        margin-bottom: 5pt !important;
+    }
     .timer-sheet-content {
         column-count: 1 !important;
     }
@@ -11,56 +20,62 @@
         display: block;
     }
     .lane-header {
-        font-size: 14pt;
+        font-size: 13pt;
         font-weight: bold;
         text-align: center;
-        margin-bottom: 5pt;
+        margin-bottom: 4pt;
         background-color: #f0f0f0;
-        padding: 4pt;
+        padding: 3pt;
         border: 1pt solid #000;
     }
     .timer-table {
         width: 100%;
         border-collapse: collapse;
-        margin-top: 5pt;
+        margin-top: 4pt;
     }
     .timer-table th {
         border: 1pt solid #333;
-        padding: 3pt;
-        font-size: 8.5pt;
+        padding: 2.5pt;
+        font-size: 8pt;
         background-color: #eee;
         text-align: center;
     }
     .timer-table td {
         border: 1pt solid #333;
-        padding: 4pt;
-        height: 44pt; /* Targeted height to fit exactly 12 rows on one page */
+        padding: 3pt 4pt;
+        height: 30pt; /* Default height for individual swimmer rows */
         vertical-align: middle;
     }
+    .timer-table tr.blank-row td {
+        height: 18pt; /* Shrunk height for no swimmer */
+    }
+    .timer-table tr.relay-row td {
+        height: 42pt; /* Taller height for relay rows */
+    }
     .timer-table td.event-header-row-cell {
-        height: auto;
-        padding: 4pt 6pt;
+        height: 18pt;
+        padding: 2pt 6pt;
         background-color: #e5e7eb;
         font-weight: bold;
-        font-size: 9.5pt;
+        font-size: 9pt;
         text-align: left;
         border: 1pt solid #333;
     }
     .col-ev-ht { 
-        width: 50pt; 
+        width: 45pt; 
         text-align: center; 
         font-weight: bold;
-        font-size: 10pt;
+        font-size: 9pt;
     }
     .col-name-team { width: auto; }
     .col-seed { 
-        width: 60pt; 
+        width: 55pt; 
         text-align: center; 
         font-family: monospace; 
         font-weight: bold;
-        font-size: 11pt;
+        font-size: 9.5pt;
     }
-    .col-timer { width: 75pt; }
+    .col-timer { width: 70pt; }
     
     .swimmer-info-block {
         display: block;
@@ -68,21 +83,21 @@
     }
     .swimmer-name {
         font-weight: bold;
-        font-size: 10pt;
-        line-height: 1.1;
+        font-size: 9.5pt;
+        line-height: 1.05;
     }
     .team-name {
-        font-size: 9pt;
+        font-size: 8.5pt;
         color: #333;
-        line-height: 1.1;
+        line-height: 1.05;
     }
     
     .relay-swimmers-grid {
         display: table;
         width: 100%;
         table-layout: fixed;
-        margin-top: 2pt;
-        font-size: 8pt;
+        margin-top: 1pt;
+        font-size: 7.5pt;
         line-height: 1.0;
         color: #444;
     }
@@ -108,7 +123,7 @@
         background-color: #fafafa;
     }
     .blank-text {
-        font-size: 9pt;
+        font-size: 8.5pt;
         color: #999;
         font-style: italic;
         text-align: center;
@@ -141,7 +156,7 @@
                         </tr>
                     {% else %}
                         {% set entry = row.item %}
-                        <tr class="timer-row {% if entry.is_blank %}blank-row{% endif %}">
+                        <tr class="timer-row {% if entry.is_blank %}blank-row{% elif entry.is_relay %}relay-row{% endif %}">
                             <td class="col-ev-ht">
                                 {{ entry.event_num }} / {{ entry.heat }}
                             </td>


### PR DESCRIPTION
This PR optimizes the page density for the Lane Timer Sheets report by reducing margins, row heights (including shorter blank rows), and using a dynamic page height point system instead of a fixed 12-row limit. Closes #508.