### PR TITLE
fix: remove underpopulated and zero entry warnings for events

### DIFF
--- a/.agent/skills/meet-validation/SKILL.md
+++ b/.agent/skills/meet-validation/SKILL.md
@@ -24,14 +24,10 @@ When checking meet data, apply these TVSL Rules logic:
 - **Exhibition Exemption**: Swims marked as exhibition (`Pre_exh` or `Fin_exh` containing non-empty characters in `entry` or `relay` tables) do **not** count towards the athlete's entry limits.
 - **Relay Event Entry**: Relay entries must be looked up in the `relay` table (linked to the athlete via the `relaynames` table). Relays are not present in the individual `entry` table.
 
-### 2. Event Entry Counts (Warnings)
-- For every event in the meet, calculate the number of entries.
-- If an event has 0 entries, generate a warning.
-- **Crucial**: Ensure relay entries are counted from the `relay` table rather than the `entry` table, as relay events do not have rows in the `entry` table.
-
-### 3. Points Awarded with DQs
+### 2. Points Awarded with DQs
 - A swimmer/relay with status `"Q"` (DQ) or a place of `0` must **not** receive points.
 - If points (`score` > 0) are found on a DQ entry, it indicates the event was not rescored after the DQ was entered.
 
-### 4. No Show (NS) / Missing Times
+### 3. No Show (NS) / Missing Times
 - Generates informational logs of scheduled swims that have no time and no status (or `"NS"` status), indicating possible stopwatch or manual entry failures.
+

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -188,6 +188,6 @@ All agents MUST follow these workflow phases:
 ### 19. Meet Validation Mappings & Exhibition Bypasses
 - **Modular Design**: Business logic validations are decoupled from the gRPC transport layer. All integrity rules reside in `meet_validation.py`.
 - **Exhibition Swims**: Exhibition swims are marked by a non-empty `Pre_exh` or `Fin_exh` column in the `entry` (or `relay` for teams) tables. These do NOT count against TVSL rules limits (max 3 individual / 4 total events).
-- **Event Entry Counting**: When calculating event entries to detect under-populated events, ensure relay events are counted from the `relay` table, as they do not have corresponding entries in the `entry` table.
+
 
 

--- a/backend/src/meet_validation.py
+++ b/backend/src/meet_validation.py
@@ -149,10 +149,9 @@ def validate_meet_data(cache: dict[str, Any]) -> list[Any]:
 
     # Map entries by athlete: maps ath_id -> list of dict {"evt_id": evt_id, "is_exhibition": bool}
     athlete_entries: dict[int, list[dict[str, Any]]] = collections.defaultdict(list)
-    event_entries_count: dict[int, int] = collections.defaultdict(int)
     event_times: dict[int, list[tuple[float, int, int, str]]] = collections.defaultdict(list)
 
-    # 1. Map individual entries to athlete_entries & count event entries
+    # 1. Map individual entries to athlete_entries
     for entry in entries:
         ath_id = safe_int(get_field(entry, ["ath_no", "Ath_no"]))
         evt_id = safe_int(get_field(entry, ["event_ptr", "Event_ptr"]) or get_field(entry, ["event_no", "Event_no"]))
@@ -162,8 +161,6 @@ def validate_meet_data(cache: dict[str, Any]) -> list[Any]:
 
         if ath_id and evt_id:
             athlete_entries[ath_id].append({"evt_id": evt_id, "is_exhibition": is_exh})
-        if evt_id:
-            event_entries_count[evt_id] += 1
 
     # 2. Map relay team exhibition status to (evt_ptr, team_no, relay_no)
     relay_exh_map = {}
@@ -175,9 +172,6 @@ def validate_meet_data(cache: dict[str, Any]) -> list[Any]:
         fin_exh = str(get_field(r, ["fin_exh", "Fin_exh"]) or "").strip().upper()
         is_exh = pre_exh != "" or fin_exh != ""
         relay_exh_map[(evt_id, t_no, r_no)] = is_exh
-        if evt_id:
-            # Fix: count relay entries so they do not trigger false positive "0 entries" warnings
-            event_entries_count[evt_id] += 1
 
     # 3. Map relay names (leg assignments) to athlete_entries
     for rn in relay_names:
@@ -470,32 +464,6 @@ def validate_meet_data(cache: dict[str, Any]) -> list[Any]:
                     category="Rules Limit",
                     message=f"Swimmer {name} exceeds total entry limits with {ind_count + rel_count} total entries (max: 4).",
                     affected_id=str(ath_id),
-                )
-            )
-
-    # 2. Event/Heat Validations
-    for e in events:
-        e_ptr = safe_int(get_field(e, ["event_ptr", "Event_ptr"]) or get_field(e, ["event_no", "Event_no"]))
-        e_no = safe_int(get_field(e, ["event_no", "Event_no"]))
-        count = event_entries_count.get(e_ptr, 0)
-
-        # INFO: Underfilled events
-        if count == 0:
-            findings.append(
-                pb2.ValidationFinding(
-                    severity=pb2.VALIDATION_SEVERITY_WARNING,
-                    category="Events",
-                    message=f"Event {e_no} has 0 entries.",
-                    affected_id=str(e_ptr),
-                )
-            )
-        elif count < 3:
-            findings.append(
-                pb2.ValidationFinding(
-                    severity=pb2.VALIDATION_SEVERITY_INFO,
-                    category="Events",
-                    message=f"Event {e_no} is under-populated with only {count} entries.",
-                    affected_id=str(e_ptr),
                 )
             )
 

--- a/backend/tests/test_meet_validation.py
+++ b/backend/tests/test_meet_validation.py
@@ -104,7 +104,6 @@ def test_validate_meet_logic():
     # 4. Parker (Male) entered in Female event (WARNING)
     # 5. Parker (age 10) entered in 15-18 event (WARNING)
     # 6. Parker exceeds TVSL entry limit with 5 entries (WARNING)
-    # 7. Event 2 has 1 entry (under-populated INFO)
 
     severities = [f.severity for f in findings]
     categories = [f.category for f in findings]
@@ -282,38 +281,25 @@ def test_exhibition_swims_limits():
     assert "Rules Limit" not in categories
 
 
-def test_relay_event_count_no_warning():
-    """Test that a relay event with entries does not trigger the 0 entries warning."""
+def test_no_event_entry_count_warnings():
+    """Test that events with zero or few entries do not trigger any warnings or findings."""
     cache = {
         "athlete": [],
         "team": [],
         "event": [
-            # Relay event
             {
                 "event_ptr": 10,
                 "event_no": 1,
                 "event_sex": "M",
                 "low_age": 0,
                 "high_age": 0,
-                "event_relay": 1,
+                "event_relay": 0,
             },
         ],
         "entry": [],
-        "relay": [
-            # Relay entry in event 10
-            {
-                "event_ptr": 10,
-                "team_no": 100,
-                "relay_no": 1,
-            }
-        ],
+        "relay": [],
     }
 
     findings = validate_meet_data(cache)
-    # The relay event has 1 entry, so it should trigger the underpopulated (INFO) warning instead of 0 entries (WARNING)
-    warning_findings = [f for f in findings if f.category == "Events" and f.severity == pb2.VALIDATION_SEVERITY_WARNING]
-    info_findings = [f for f in findings if f.category == "Events" and f.severity == pb2.VALIDATION_SEVERITY_INFO]
-
-    assert len(warning_findings) == 0
-    assert len(info_findings) == 1
-    assert "under-populated" in info_findings[0].message
+    event_findings = [f for f in findings if f.category == "Events"]
+    assert len(event_findings) == 0


### PR DESCRIPTION
Removes the warnings for events with 0 or few entries from meet validations as it is common to have few or zero entries in some events.