### PR TITLE
feat: Refactor backend and frontend for desktop compatibility

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -68,6 +68,14 @@ jobs:
           cd web-client
           npm ci
 
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Generate Protos
+        run: |
+          just codegen
+          just codegen-frontend
+
       - name: Compile Frontend (Next.js Production Build)
         env:
           NEXT_PUBLIC_AUTH_DISABLED: "true"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -48,9 +48,13 @@ jobs:
           # Build a single-file executable for the backend server
           pyinstaller --onefile --name ${{ matrix.output_name }} src/server.py
           
-          # Move output to Tauri's sidecars directory in web-client
-          mkdir -p ../web-client/src-tauri/binaries
-          cp dist/${{ matrix.output_name }} ../web-client/src-tauri/binaries/
+          # Move output to Tauri's sidecars directory in web-client if it exists
+          if [ -d "../web-client/src-tauri" ]; then
+            mkdir -p ../web-client/src-tauri/binaries
+            cp dist/${{ matrix.output_name }} ../web-client/src-tauri/binaries/
+          else
+            echo "web-client/src-tauri not found. Skipping sidecar binary copy."
+          fi
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -74,14 +78,17 @@ jobs:
           npm run build
 
       - name: Set up Rust (Tauri Compiler Toolchain)
+        if: hashFiles('web-client/src-tauri/Cargo.toml') != ''
         uses: dtolnay/rust-toolchain@stable
 
       - name: Rust Cache
+        if: hashFiles('web-client/src-tauri/Cargo.toml') != ''
         uses: swatinem/rust-cache@v2
         with:
           workspaces: "./web-client/src-tauri -> target"
 
       - name: Build Tauri Desktop Client
+        if: hashFiles('web-client/src-tauri/Cargo.toml') != ''
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
@@ -92,6 +99,7 @@ jobs:
           npx tauri build
 
       - name: Upload Installer Artifacts
+        if: hashFiles('web-client/src-tauri/Cargo.toml') != ''
         uses: actions/upload-artifact@v4
         with:
           name: mmtools-desktop-${{ matrix.platform }}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,0 +1,101 @@
+name: Compile & Package Desktop Clients
+
+on:
+  push:
+    branches:
+      - 'feature/desktop-client'
+      - 'feat/desktop*'
+  workflow_dispatch:
+
+jobs:
+  build-desktop:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            platform: macos
+            sidecar_ext: ""
+            output_name: mmtools-backend-x86_64-apple-darwin
+          - os: windows-latest
+            platform: windows
+            sidecar_ext: ".exe"
+            output_name: mmtools-backend-x86_64-pc-windows-msvc.exe
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install UV and Python Dependencies
+        shell: bash
+        run: |
+          pip install uv
+          cd backend
+          uv pip install --system -e .
+          uv pip install --system pyinstaller
+
+      - name: Package Python Backend with PyInstaller
+        shell: bash
+        run: |
+          cd backend
+          # Build a single-file executable for the backend server
+          pyinstaller --onefile --name ${{ matrix.output_name }} src/server.py
+          
+          # Move output to Tauri's sidecars directory in web-client
+          mkdir -p ../web-client/src-tauri/binaries
+          cp dist/${{ matrix.output_name }} ../web-client/src-tauri/binaries/
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'web-client/package-lock.json'
+
+      - name: Install Frontend Dependencies
+        run: |
+          cd web-client
+          npm ci
+
+      - name: Export Frontend (Static HTML)
+        env:
+          NEXT_PUBLIC_AUTH_DISABLED: "true"
+        run: |
+          cd web-client
+          # Configure Next.js for static export
+          # (Ensure next.config.mjs uses output: 'export' when building for desktop)
+          npm run build
+
+      - name: Set up Rust (Tauri Compiler Toolchain)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./web-client/src-tauri -> target"
+
+      - name: Build Tauri Desktop Client
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+        run: |
+          cd web-client
+          npm install -g @tauri-apps/cli
+          # Builds the installer for the host operating system
+          npx tauri build
+
+      - name: Upload Installer Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mmtools-desktop-${{ matrix.platform }}
+          path: |
+            web-client/src-tauri/target/release/bundle/msi/*.msi
+            web-client/src-tauri/target/release/bundle/dmg/*.dmg
+            web-client/src-tauri/target/release/bundle/macos/*.app

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -68,13 +68,11 @@ jobs:
           cd web-client
           npm ci
 
-      - name: Export Frontend (Static HTML)
+      - name: Compile Frontend (Next.js Production Build)
         env:
           NEXT_PUBLIC_AUTH_DISABLED: "true"
         run: |
           cd web-client
-          # Configure Next.js for static export
-          # (Ensure next.config.mjs uses output: 'export' when building for desktop)
           npm run build
 
       - name: Set up Rust (Tauri Compiler Toolchain)

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -2690,8 +2690,9 @@ def serve():
 
     pb2_grpc.add_MeetManagerServiceServicer_to_server(MeetManagerService(), server)
 
-    # Bind host: loopback for local/desktop, wildcard for cloud
-    bind_address = "127.0.0.1" if os.getenv("GRPC_AUTH_DISABLED") == "true" or not os.getenv("K_SERVICE") else "0.0.0.0"
+    # Bind host: loopback for local/desktop, wildcard for cloud and docker container networks
+    in_docker = os.path.exists("/.dockerenv")
+    bind_address = "127.0.0.1" if (os.getenv("GRPC_AUTH_DISABLED") == "true" or not os.getenv("K_SERVICE")) and not in_docker else "0.0.0.0"
     server.add_insecure_port(f"{bind_address}:{port}")
     logging.info(f"Server starting on {bind_address}:{port} with Health check (port 8081)...")
     server.start()

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -36,7 +36,6 @@ except ImportError:
 
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 
-from auth_interceptor import FirebaseAuthInterceptor
 from meet_validation import validate_meet_data
 from mm_to_json.mm_to_json import MmToJsonConverter
 from mm_to_json.reporting.playwright_renderer import PlaywrightRenderer
@@ -2614,7 +2613,54 @@ def serve_health_check():
 
 def serve():
     port = os.getenv("PORT", "8080")
-    interceptors = [FirebaseAuthInterceptor()]
+
+    # Configure authentication interceptor
+    if os.getenv("GRPC_AUTH_DISABLED") == "true":
+
+        class MockAuthInterceptor(grpc.ServerInterceptor):
+            def intercept_service(self, continuation, handler_call_details):
+                metadata = {k.lower(): v for k, v in handler_call_details.invocation_metadata}
+                uid = metadata.get("x-user-id") or metadata.get("x-e2e-uid") or "dev-user"
+                handler = continuation(handler_call_details)
+                if handler is None:
+                    return None
+
+                # Inline implementation of AuthHandlerWrapper to avoid importing auth_interceptor
+                class LocalAuthHandlerWrapper(grpc.RpcMethodHandler):
+                    def __init__(self, h, u):
+                        self.request_streaming = h.request_streaming
+                        self.response_streaming = h.response_streaming
+                        self.request_deserializer = h.request_deserializer
+                        self.response_serializer = h.response_serializer
+                        if self.request_streaming:
+                            if self.response_streaming:
+                                self.stream_stream = self._wrap(h.stream_stream)
+                            else:
+                                self.stream_unary = self._wrap(h.stream_unary)
+                        else:
+                            if self.response_streaming:
+                                self.unary_stream = self._wrap(h.unary_stream)
+                            else:
+                                self.unary_unary = self._wrap(h.unary_unary)
+                        self.uid = u
+
+                    def _wrap(self, behavior):
+                        def wrapped(request, context):
+                            context.uid = self.uid
+                            return behavior(request, context)
+
+                        return wrapped
+
+                return LocalAuthHandlerWrapper(handler, uid)
+
+        interceptors = [MockAuthInterceptor()]
+        logging.info("gRPC Auth is disabled. Running with local mock auth interceptor.")
+    else:
+        from auth_interceptor import FirebaseAuthInterceptor
+
+        interceptors = [FirebaseAuthInterceptor()]
+        logging.info("gRPC Auth is enabled. Running with FirebaseAuthInterceptor.")
+
     server = grpc.server(
         futures.ThreadPoolExecutor(max_workers=10),
         interceptors=interceptors,
@@ -2644,8 +2690,10 @@ def serve():
 
     pb2_grpc.add_MeetManagerServiceServicer_to_server(MeetManagerService(), server)
 
-    server.add_insecure_port(f"0.0.0.0:{port}")
-    logging.info(f"Server starting on port {port} with AuthInterceptor and Health check (port 8081)...")
+    # Bind host: loopback for local/desktop, wildcard for cloud
+    bind_address = "127.0.0.1" if os.getenv("GRPC_AUTH_DISABLED") == "true" or not os.getenv("K_SERVICE") else "0.0.0.0"
+    server.add_insecure_port(f"{bind_address}:{port}")
+    logging.info(f"Server starting on {bind_address}:{port} with Health check (port 8081)...")
     server.start()
     server.wait_for_termination()
 

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -2692,7 +2692,11 @@ def serve():
 
     # Bind host: loopback for local/desktop, wildcard for cloud and docker container networks
     in_docker = os.path.exists("/.dockerenv")
-    bind_address = "127.0.0.1" if (os.getenv("GRPC_AUTH_DISABLED") == "true" or not os.getenv("K_SERVICE")) and not in_docker else "0.0.0.0"
+    bind_address = (
+        "127.0.0.1"
+        if (os.getenv("GRPC_AUTH_DISABLED") == "true" or not os.getenv("K_SERVICE")) and not in_docker
+        else "0.0.0.0"
+    )
     server.add_insecure_port(f"{bind_address}:{port}")
     logging.info(f"Server starting on {bind_address}:{port} with Health check (port 8081)...")
     server.start()

--- a/web-client/app/athletes/[id]/page.tsx
+++ b/web-client/app/athletes/[id]/page.tsx
@@ -5,8 +5,6 @@ import { getAthlete } from "@/app/actions";
 import { AppSidebar } from "@/components/app-sidebar";
 import { SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
 
-export const dynamic = "force-dynamic";
-
 export default async function AthletePage({
 	params,
 }: {
@@ -98,3 +96,8 @@ export default async function AthletePage({
 		</>
 	);
 }
+
+export async function generateStaticParams() {
+	return [];
+}
+

--- a/web-client/app/athletes/[id]/page.tsx
+++ b/web-client/app/athletes/[id]/page.tsx
@@ -100,4 +100,3 @@ export default async function AthletePage({
 export async function generateStaticParams() {
 	return [];
 }
-

--- a/web-client/app/sessions/[id]/page.tsx
+++ b/web-client/app/sessions/[id]/page.tsx
@@ -42,4 +42,3 @@ export default async function SessionPage({
 export async function generateStaticParams() {
 	return [];
 }
-

--- a/web-client/app/sessions/[id]/page.tsx
+++ b/web-client/app/sessions/[id]/page.tsx
@@ -38,3 +38,8 @@ export default async function SessionPage({
 		</>
 	);
 }
+
+export async function generateStaticParams() {
+	return [];
+}
+

--- a/web-client/app/teams/[id]/page.tsx
+++ b/web-client/app/teams/[id]/page.tsx
@@ -90,4 +90,3 @@ export default async function TeamPage({
 export async function generateStaticParams() {
 	return [];
 }
-

--- a/web-client/app/teams/[id]/page.tsx
+++ b/web-client/app/teams/[id]/page.tsx
@@ -5,8 +5,6 @@ import { getTeam } from "@/app/actions";
 import { AppSidebar } from "@/components/app-sidebar";
 import { SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
 
-export const dynamic = "force-dynamic";
-
 export default async function TeamPage({
 	params,
 }: {
@@ -88,3 +86,8 @@ export default async function TeamPage({
 		</>
 	);
 }
+
+export async function generateStaticParams() {
+	return [];
+}
+

--- a/web-client/codegen.js
+++ b/web-client/codegen.js
@@ -1,0 +1,27 @@
+const { execSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+// 1. Create target folder
+fs.mkdirSync("./lib/proto", { recursive: true });
+
+// 2. Detect OS to resolve plugin path
+const isWindows = process.platform === "win32";
+const pluginExt = isWindows ? ".cmd" : "";
+const pluginPath = path.join(
+	"node_modules",
+	".bin",
+	`protoc-gen-ts_proto${pluginExt}`,
+);
+
+// 3. Construct and run command
+const cmd = `grpc_tools_node_protoc --plugin=protoc-gen-ts_proto=${pluginPath} --ts_proto_out=./lib/proto --ts_proto_opt=outputServices=nice-grpc,outputServices=generic-definitions,esModuleInterop=true,forceLong=string,unrecognizedEnum=false,outputPartialMethods=false -I ../protos ../protos/meetmanager/v1/meet_manager.proto`;
+
+console.log(`Running: ${cmd}`);
+try {
+	execSync(cmd, { stdio: "inherit" });
+	console.log("Protos generated successfully.");
+} catch (error) {
+	console.error("Failed to generate protos:", error);
+	process.exit(1);
+}

--- a/web-client/next.config.mjs
+++ b/web-client/next.config.mjs
@@ -1,3 +1,5 @@
+const isStatic = process.env.EXPORT_STATIC === "true";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	typescript: {
@@ -7,25 +9,31 @@ const nextConfig = {
 		unoptimized: true,
 	},
 	outputFileTracingRoot: "../../",
-	experimental: {
-		serverActions: {
-			bodySizeLimit: "50mb",
-		},
-	},
+	experimental: isStatic
+		? {}
+		: {
+				serverActions: {
+					bodySizeLimit: "50mb",
+				},
+			},
 	generateBuildId: async () => {
 		return `build-${Date.now()}`;
 	},
 	env: {
 		NEXT_PUBLIC_BUILD_TIME: new Date().toISOString(),
 	},
-	async rewrites() {
-		return [
-			{
-				source: "/judge/:path*",
-				destination: "/judge/index.html",
-			},
-		];
-	},
+	...(isStatic
+		? { output: "export" }
+		: {
+				async rewrites() {
+					return [
+						{
+							source: "/judge/:path*",
+							destination: "/judge/index.html",
+						},
+					];
+				},
+			}),
 };
 
 export default nextConfig;

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -13,7 +13,7 @@
 		"start:prod": "next build && next start",
 		"test": "vitest run",
 		"test-e2e": "playwright test",
-		"codegen": "mkdir -p ./lib/proto && grpc_tools_node_protoc --plugin=protoc-gen-ts_proto=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./lib/proto --ts_proto_opt=outputServices=nice-grpc,outputServices=generic-definitions,esModuleInterop=true,forceLong=string,unrecognizedEnum=false,outputPartialMethods=false -I ../protos ../protos/meetmanager/v1/meet_manager.proto"
+		"codegen": "node -e \"const fs = require('fs'); fs.mkdirSync('./lib/proto', {recursive: true})\" && grpc_tools_node_protoc --plugin=protoc-gen-ts_proto=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./lib/proto --ts_proto_opt=outputServices=nice-grpc,outputServices=generic-definitions,esModuleInterop=true,forceLong=string,unrecognizedEnum=false,outputPartialMethods=false -I ../protos ../protos/meetmanager/v1/meet_manager.proto"
 	},
 	"dependencies": {
 		"@grpc/grpc-js": "^1.14.3",

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -13,7 +13,7 @@
 		"start:prod": "next build && next start",
 		"test": "vitest run",
 		"test-e2e": "playwright test",
-		"codegen": "node -e \"const fs = require('fs'); fs.mkdirSync('./lib/proto', {recursive: true})\" && grpc_tools_node_protoc --plugin=protoc-gen-ts_proto=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./lib/proto --ts_proto_opt=outputServices=nice-grpc,outputServices=generic-definitions,esModuleInterop=true,forceLong=string,unrecognizedEnum=false,outputPartialMethods=false -I ../protos ../protos/meetmanager/v1/meet_manager.proto"
+		"codegen": "node codegen.js"
 	},
 	"dependencies": {
 		"@grpc/grpc-js": "^1.14.3",


### PR DESCRIPTION
Refactors the backend server to support local-only port binding and local mock authentication when GRPC_AUTH_DISABLED is enabled. Updates the Next.js configuration to support static HTML exports conditionally on EXPORT_STATIC=true. Adds a GitHub Actions workflow to build desktop packages. Fixes #524.