### PR TITLE
fix: disable auth in static tauri build and add trust-app script

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -114,3 +114,4 @@ jobs:
             web-client/src-tauri/target/release/bundle/msi/*.msi
             web-client/src-tauri/target/release/bundle/dmg/*.dmg
             web-client/src-tauri/target/release/bundle/macos/*.app
+            scripts/trust-app.command

--- a/scripts/trust-app.command
+++ b/scripts/trust-app.command
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Move to the script's directory
+cd "$(dirname "$0")"
+
+echo "================================================="
+echo "  MeetManager Tools macOS App Trust Utility"
+echo "================================================="
+echo ""
+echo "This script strips the macOS Gatekeeper quarantine flag"
+echo "from MeetManager-Tools.app so it can launch cleanly."
+echo ""
+
+TARGET_APP="MeetManager-Tools.app"
+
+if [ -d "$TARGET_APP" ]; then
+    echo "Found app in local directory: $TARGET_APP"
+    xattr -rd com.apple.quarantine "$TARGET_APP"
+    echo "Successfully updated permissions! You can now open MeetManager-Tools.app."
+elif [ -d "/Applications/MeetManager-Tools.app" ]; then
+    echo "Found app in Applications directory: /Applications/MeetManager-Tools.app"
+    xattr -rd com.apple.quarantine "/Applications/MeetManager-Tools.app"
+    echo "Successfully updated permissions! You can now open the app from Applications."
+else
+    echo "Could not find MeetManager-Tools.app in the current folder or /Applications."
+    echo "Please place this script in the same folder as the app and run again."
+fi
+
+echo ""
+read -p "Press Enter to exit..."

--- a/scripts/trust-app.command
+++ b/scripts/trust-app.command
@@ -3,25 +3,25 @@
 cd "$(dirname "$0")"
 
 echo "================================================="
-echo "  MeetManager Tools macOS App Trust Utility"
+echo "  MM-Tools macOS App Trust Utility"
 echo "================================================="
 echo ""
 echo "This script strips the macOS Gatekeeper quarantine flag"
-echo "from MeetManager-Tools.app so it can launch cleanly."
+echo "from MM-Tools.app so it can launch cleanly."
 echo ""
 
-TARGET_APP="MeetManager-Tools.app"
+TARGET_APP="MM-Tools.app"
 
 if [ -d "$TARGET_APP" ]; then
     echo "Found app in local directory: $TARGET_APP"
     xattr -rd com.apple.quarantine "$TARGET_APP"
-    echo "Successfully updated permissions! You can now open MeetManager-Tools.app."
-elif [ -d "/Applications/MeetManager-Tools.app" ]; then
-    echo "Found app in Applications directory: /Applications/MeetManager-Tools.app"
-    xattr -rd com.apple.quarantine "/Applications/MeetManager-Tools.app"
+    echo "Successfully updated permissions! You can now open MM-Tools.app."
+elif [ -d "/Applications/MM-Tools.app" ]; then
+    echo "Found app in Applications directory: /Applications/MM-Tools.app"
+    xattr -rd com.apple.quarantine "/Applications/MM-Tools.app"
     echo "Successfully updated permissions! You can now open the app from Applications."
 else
-    echo "Could not find MeetManager-Tools.app in the current folder or /Applications."
+    echo "Could not find MM-Tools.app in the current folder or /Applications."
     echo "Please place this script in the same folder as the app and run again."
 fi
 

--- a/web-client/app/api/test/auth/route.ts
+++ b/web-client/app/api/test/auth/route.ts
@@ -18,14 +18,14 @@ export async function GET(request: Request) {
 
 	response.cookies.set("idToken", "dev-token", {
 		httpOnly: true,
-		secure: process.env.NODE_ENV === "production",
+		secure: false,
 		sameSite: "strict",
 		path: "/",
 	});
 
 	response.cookies.set("x-user-id", mockUid, {
 		httpOnly: false,
-		secure: process.env.NODE_ENV === "production",
+		secure: false,
 		sameSite: "strict",
 		path: "/",
 	});

--- a/web-client/src-tauri/tauri.conf.json
+++ b/web-client/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
-	"productName": "MeetManager-Tools",
+	"productName": "MM-Tools",
 	"version": "0.1.0",
 	"identifier": "com.mmtools.desktop",
 	"build": {

--- a/web-client/src-tauri/tauri.conf.json
+++ b/web-client/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
 		"frontendDist": "../out",
 		"devUrl": "http://localhost:3000",
 		"beforeDevCommand": "npm run dev",
-		"beforeBuildCommand": "npx cross-env EXPORT_STATIC=true npm run build"
+		"beforeBuildCommand": "npx cross-env EXPORT_STATIC=true NEXT_PUBLIC_AUTH_DISABLED=true npm run build"
 	},
 	"app": {
 		"windows": [


### PR DESCRIPTION
Bakes NEXT_PUBLIC_AUTH_DISABLED=true into beforeBuildCommand for static Next.js compilation, preventing Google Sign-in hangs in desktop mode. Also creates and packages trust-app.command for macOS users to bypass the Gatekeeper quarantine warning.