### PR TITLE
fix: add diagnostic logs to google picker builder

### DIFF
--- a/web-client/hooks/use-google-picker.ts
+++ b/web-client/hooks/use-google-picker.ts
@@ -102,6 +102,14 @@ export function useGooglePicker({
 			return;
 		}
 
+		console.log("[Google Picker Debug] Initializing with:", {
+			hasAccessToken: !!currentToken,
+			appId: appId,
+			origin: typeof window !== "undefined" ? window.location.origin : null,
+			apiKeyPrefix: apiKey ? `${apiKey.substring(0, 8)}...` : "none",
+			apiKeyLength: apiKey?.length || 0,
+		});
+
 		const builder = new window.google.picker.PickerBuilder()
 			.addView(window.google.picker.ViewId.DOCS)
 			.setOAuthToken(currentToken)


### PR DESCRIPTION
Outputs GAPI initialization params to the browser console to help diagnose invalid developer key issues on Cloud Run.