### PR TITLE
fix: ignore unscored relays in Relays with NS validation check

### DIFF
--- a/backend/src/meet_validation.py
+++ b/backend/src/meet_validation.py
@@ -357,22 +357,25 @@ def validate_meet_data(cache: dict[str, Any]) -> list[Any]:
         r_heat = safe_int(get_field(r, ["fin_heat", "Fin_heat"]))
         r_lane = safe_int(get_field(r, ["fin_lane", "Fin_lane"]))
         if r_heat > 0 and r_lane > 0:
-            r_time = safe_float(get_field(r, ["fin_time", "Fin_time"]))
+            r_place = safe_int(get_field(r, ["fin_place", "place", "Fin_place"]))
             r_stat = safe_str(get_field(r, ["fin_stat", "Fin_stat"])).upper()
-            if r_time == 0 and r_stat not in ["Q", "R"]:
-                t_id = safe_int(get_field(r, ["team_ptr", "team_no", "Team_ptr", "Team_no"]))
-                team_name = teams_map.get(t_id, {}).get("name", f"Team #{t_id}")
-                team_ltr = safe_str(get_field(r, ["team_ltr", "Team_ltr"]))
-                evt_id = safe_int(get_field(r, ["event_ptr", "Event_ptr"]))
-                evt_desc = events_map.get(evt_id, {}).get("desc", f"Event {evt_id}")
-                findings.append(
-                    pb2.ValidationFinding(
-                        severity=pb2.VALIDATION_SEVERITY_INFO,
-                        category="Relays with NS",
-                        message=f"Team {team_name} '{team_ltr}' in {evt_desc} (Heat {r_heat}, Lane {r_lane}): Relay has NS/Missing Time.",
-                        affected_id=str(t_id),
+            is_scored = (r_place > 0) or (r_stat != "")
+            if is_scored:
+                r_time = safe_float(get_field(r, ["fin_time", "Fin_time"]))
+                if r_time == 0 and r_stat not in ["Q", "R"]:
+                    t_id = safe_int(get_field(r, ["team_ptr", "team_no", "Team_ptr", "Team_no"]))
+                    team_name = teams_map.get(t_id, {}).get("name", f"Team #{t_id}")
+                    team_ltr = safe_str(get_field(r, ["team_ltr", "Team_ltr"]))
+                    evt_id = safe_int(get_field(r, ["event_ptr", "Event_ptr"]))
+                    evt_desc = events_map.get(evt_id, {}).get("desc", f"Event {evt_id}")
+                    findings.append(
+                        pb2.ValidationFinding(
+                            severity=pb2.VALIDATION_SEVERITY_INFO,
+                            category="Relays with NS",
+                            message=f"Team {team_name} '{team_ltr}' in {evt_desc} (Heat {r_heat}, Lane {r_lane}): Relay has NS/Missing Time.",
+                            affected_id=str(t_id),
+                        )
                     )
-                )
 
     # 5. Duplicate Times (WARNING)
     for evt_id, times_list in event_times.items():

--- a/backend/tests/test_meet_validation.py
+++ b/backend/tests/test_meet_validation.py
@@ -214,6 +214,7 @@ def test_new_validation_rules():
                 "fin_stat": "",
                 "fin_heat": 1,
                 "fin_lane": 1,
+                "fin_place": 1,
             }
         ],
     }
@@ -413,3 +414,64 @@ def test_rules_limits_with_relays():
     categories_msgs = [f.message for f in limit_findings3]
     assert any("exceeds relay limits" in m for m in categories_msgs)
     assert any("exceeds total entry limits" in m for m in categories_msgs)
+
+
+def test_relays_with_ns_scored_logic():
+    """Verify that unscored relays are not flagged by the 'Relays with NS' validation check."""
+    cache = {
+        "athlete": [],
+        "team": [{"team_no": 100, "team_name": "Del Prado", "team_lsc": "DP"}],
+        "event": [
+            {"event_ptr": 72, "event_no": 72, "event_sex": "M", "low_age": 9, "high_age": 10, "ind_rel": "R"},
+        ],
+        "entry": [],
+        "relay": [
+            # 1. Unscored relay (should be ignored)
+            {
+                "event_ptr": 72,
+                "relay_no": 1,
+                "team_no": 100,
+                "team_ltr": "A",
+                "fin_heat": 1,
+                "fin_lane": 4,
+                "fin_time": 0.0,
+                "fin_stat": "",
+                "fin_place": 0,
+            },
+            # 2. Scored relay but with NS/No Time (should be flagged)
+            {
+                "event_ptr": 72,
+                "relay_no": 2,
+                "team_no": 100,
+                "team_ltr": "B",
+                "fin_heat": 1,
+                "fin_lane": 5,
+                "fin_time": 0.0,
+                "fin_stat": "NS",
+                "fin_place": 0,
+            },
+            # 3. Scored relay with a place but missing time (should be flagged)
+            {
+                "event_ptr": 72,
+                "relay_no": 3,
+                "team_no": 100,
+                "team_ltr": "C",
+                "fin_heat": 1,
+                "fin_lane": 6,
+                "fin_time": 0.0,
+                "fin_stat": "",
+                "fin_place": 3,
+            },
+        ],
+        "relaynames": [],
+    }
+
+    findings = validate_meet_data(cache)
+    relay_findings = [f for f in findings if f.category == "Relays with NS"]
+
+    # We expect exactly 2 findings (B and C), since A is unscored
+    assert len(relay_findings) == 2
+    messages = [f.message for f in relay_findings]
+    assert any("Team Del Prado 'B'" in m for m in messages)
+    assert any("Team Del Prado 'C'" in m for m in messages)
+    assert not any("Team Del Prado 'A'" in m for m in messages)


### PR DESCRIPTION
Only triggers 'Relays with NS' warnings for relays that are actually scored (have a place > 0 or a non-empty status), matching the behavior for individual entries. Resolves incorrect warnings reported for unscored seeded relays when loading a new meet.