### PR TITLE
fix: ignore relay alternates in Rules Limit validation check

### DIFF
--- a/backend/src/meet_validation.py
+++ b/backend/src/meet_validation.py
@@ -192,6 +192,9 @@ def validate_meet_data(cache: dict[str, Any]) -> list[Any]:
         evt_id = safe_int(get_field(rn, ["event_ptr", "Event_ptr"]))
         t_no = safe_int(get_field(rn, ["team_no", "Team_no"]))
         r_no = safe_int(get_field(rn, ["relay_no", "Relay_no"]))
+        pos_no = safe_int(get_field(rn, ["pos_no", "pos", "Pos_no", "Pos"]))
+        if pos_no > 4:
+            continue
         if ath_id and evt_id:
             is_exh = relay_exh_map.get((evt_id, t_no, r_no), False)
             athlete_entries[ath_id].append({"evt_id": evt_id, "is_exhibition": is_exh})

--- a/backend/tests/test_meet_validation.py
+++ b/backend/tests/test_meet_validation.py
@@ -415,6 +415,27 @@ def test_rules_limits_with_relays():
     assert any("exceeds relay limits" in m for m in categories_msgs)
     assert any("exceeds total entry limits" in m for m in categories_msgs)
 
+    # Case 4: 3 individual events + 3 relay events, but one relay has pos_no = 5 (alternate)
+    # This should act like 3 individual + 2 relay events (5 total) -> exceeds total, but relay count is ok (2)
+    cache_case4 = cache.copy()
+    cache_case4["relaynames"] = [
+        {"event_ptr": 20, "team_no": 100, "team_ltr": "A", "ath_no": 1, "relay_no": 1, "event_round": "F", "pos_no": 1},
+        {"event_ptr": 21, "team_no": 100, "team_ltr": "A", "ath_no": 1, "relay_no": 2, "event_round": "F", "pos_no": 2},
+        {
+            "event_ptr": 22,
+            "team_no": 100,
+            "team_ltr": "A",
+            "ath_no": 1,
+            "relay_no": 3,
+            "event_round": "F",
+            "pos_no": 5,
+        },  # Alternate!
+    ]
+    findings4 = validate_meet_data(cache_case4)
+    limit_findings4 = [f for f in findings4 if f.category == "Rules Limit"]
+    assert len(limit_findings4) == 1
+    assert "exceeds total entry limits" in limit_findings4[0].message
+
 
 def test_relays_with_ns_scored_logic():
     """Verify that unscored relays are not flagged by the 'Relays with NS' validation check."""


### PR DESCRIPTION
Ignores relay entries where the swimmer is assigned to a position > 4 (leg 5-8 alternates), ensuring they do not count against the swimmer's relay and total event limits. Fixes incorrect limit flags for swimmers assigned as alternates in the Bay Club meet.