### PR TITLE
fix(reporting): replace copyrighted Hy-Tek Meet Manager headers with MMTools

### DIFF
--- a/backend/src/mm_to_json/reporting/playwright_renderer.py
+++ b/backend/src/mm_to_json/reporting/playwright_renderer.py
@@ -62,7 +62,7 @@ class PlaywrightRenderer:
                         <div style="font-weight: bold;">Tri-Valley Swim Lg. C</div>
                     </div>
                     <div style="text-align: right;">
-                        <div>HY-TEK's MEET MANAGER 7.0 - {gen_time} &nbsp;&nbsp; Page <span class="pageNumber"></span></div>
+                        <div>MMTools - {gen_time} &nbsp;&nbsp; Page <span class="pageNumber"></span></div>
                     </div>
                 </div>
                 <div style="display: flex; justify-content: space-between; align-items: flex-end; width: 100%;">

--- a/backend/src/mm_to_json/reporting/templates/_base_report.j2
+++ b/backend/src/mm_to_json/reporting/templates/_base_report.j2
@@ -29,7 +29,7 @@
                     <div class="header-meet-name">Tri-Valley Swim Lg. C</div>
                 </td>
                 <td class="header-right-col">
-                    <div class="header-software">HY-TEK's MEET MANAGER 7.0 - {{ generation_time }} Page <span class="page-counter"></span></div>
+                    <div class="header-software">MMTools - {{ generation_time }} Page <span class="page-counter"></span></div>
                 </td>
             </tr>
             <tr>


### PR DESCRIPTION
This PR replaces copyrighted Hy-Tek Meet Manager report headers in HTML and PDF layouts with MMTools branding.