### PR TITLE
chore(deploy): disable Cloud Run CPU throttling for backend service

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -81,7 +81,7 @@ jobs:
           service: '${{ env.BACKEND_SERVICE }}'
           image: '${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.BACKEND_SERVICE }}:${{ github.sha }}'
           region: '${{ env.REGION }}'
-          flags: '--allow-unauthenticated --memory 4Gi --cpu 4 --timeout 600s'
+          flags: '--allow-unauthenticated --memory 4Gi --cpu 4 --timeout 600s --no-cpu-throttling'
           env_vars: |
             GCS_BUCKET_NAME=mmtools-data-mmtools-488404
             LOG_LEVEL=INFO


### PR DESCRIPTION
This PR adds the --no-cpu-throttling flag to the backend Cloud Run service deployment. This prevents CPU throttling on background threads during report bundle generation.