### PR TITLE
chore(deploy): limit backend Cloud Run service to max 5 instances

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -81,7 +81,7 @@ jobs:
           service: '${{ env.BACKEND_SERVICE }}'
           image: '${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.BACKEND_SERVICE }}:${{ github.sha }}'
           region: '${{ env.REGION }}'
-          flags: '--allow-unauthenticated --memory 4Gi --cpu 4 --timeout 600s --no-cpu-throttling'
+          flags: '--allow-unauthenticated --memory 4Gi --cpu 4 --timeout 600s --no-cpu-throttling --max-instances 5'
           env_vars: |
             GCS_BUCKET_NAME=mmtools-data-mmtools-488404
             LOG_LEVEL=INFO


### PR DESCRIPTION
This PR adds the --max-instances 5 flag to the backend Cloud Run service deployment. This limits max scaling to cap billing exposure under always-on CPU allocation.