### PR TITLE
fix(tauri): fix report generation bundle download and dynamic REST port discovery

### DIFF
--- a/web-client/components/reports-manager.tsx
+++ b/web-client/components/reports-manager.tsx
@@ -218,18 +218,10 @@ export function ReportsManager({
 						const filename = _filename || "meet_reports.zip";
 
 						resolveBundleUrl(status.bundleUrl).then((resolvedUrl) => {
-							fetch(resolvedUrl)
-								.then((res) => {
-									if (!res.ok) throw new Error("Failed to download file");
-									return res.arrayBuffer();
-								})
-								.then((arrayBuffer) => {
-									downloadFile(filename, arrayBuffer);
-								})
-								.catch((err) => {
-									console.error("Programmatic download failed:", err);
-									toast.error("Failed to download reports bundle");
-								});
+							downloadFile(filename, resolvedUrl).catch((err) => {
+								console.error("Programmatic download failed:", err);
+								toast.error("Failed to download reports bundle");
+							});
 						});
 
 						// Also open any google sheets

--- a/web-client/lib/tauri-bridge.ts
+++ b/web-client/lib/tauri-bridge.ts
@@ -1,22 +1,15 @@
 import { invoke } from "@tauri-apps/api/core";
 
-let cachedRestPort: number | null = null;
-
 export async function getRestPort(): Promise<number> {
-	if (cachedRestPort !== null) return cachedRestPort;
-
 	// In E2E tests, read from window.__MM_TEST_PORT__ if set
 	if (typeof window !== "undefined" && (window as any).__MM_TEST_PORT__) {
-		cachedRestPort = (window as any).__MM_TEST_PORT__;
-		return cachedRestPort!;
+		return (window as any).__MM_TEST_PORT__;
 	}
 
 	try {
 		if (typeof window !== "undefined" && (window as any).__TAURI_INTERNALS__) {
 			const portStr = await invoke<string>("get_backend_port");
-			const restPort = Number.parseInt(portStr, 10);
-			cachedRestPort = restPort;
-			return restPort;
+			return Number.parseInt(portStr, 10) || 8081;
 		}
 	} catch (e) {
 		console.warn("Failed to get Tauri REST port, falling back to 8081", e);
@@ -113,6 +106,35 @@ export async function downloadFile(
 		try {
 			const { save } = await import("@tauri-apps/plugin-dialog");
 
+			// If content is a URL pointing to a storage file, use dynamic filesystem copy
+			if (
+				typeof content === "string" &&
+				!isBase64 &&
+				(content.startsWith("http") || content.startsWith("/api/data"))
+			) {
+				const urlObj = new URL(content);
+				const relativePath = urlObj.searchParams.get("path");
+				if (!relativePath) {
+					throw new Error("No path parameter found in download URL");
+				}
+
+				const savePath = await save({
+					defaultPath: filename,
+				});
+
+				if (!savePath) {
+					console.log("Download cancelled by user");
+					return;
+				}
+
+				await invoke("copy_file_from_storage", {
+					relativePath: relativePath,
+					destPath: savePath,
+				});
+				console.log(`Successfully copied file from storage to ${savePath}`);
+				return;
+			}
+
 			const savePath = await save({
 				defaultPath: filename,
 			});
@@ -150,7 +172,13 @@ export async function downloadFile(
 	} else {
 		// Browser fallback
 		const link = document.createElement("a");
-		if (isBase64 && typeof content === "string") {
+		if (
+			typeof content === "string" &&
+			!isBase64 &&
+			(content.startsWith("http") || content.startsWith("/api/data"))
+		) {
+			link.href = content;
+		} else if (isBase64 && typeof content === "string") {
 			link.href = `data:application/octet-stream;base64,${content}`;
 		} else if (content instanceof ArrayBuffer) {
 			const blob = new Blob([content], { type: "application/octet-stream" });
@@ -163,7 +191,7 @@ export async function downloadFile(
 		document.body.appendChild(link);
 		link.click();
 		document.body.removeChild(link);
-		if (!(content instanceof String) && typeof content !== "string") {
+		if (!(content instanceof ArrayBuffer) && typeof content !== "string") {
 			URL.revokeObjectURL(link.href);
 		}
 	}

--- a/web-client/src-tauri/src/lib.rs
+++ b/web-client/src-tauri/src/lib.rs
@@ -21,6 +21,22 @@ fn save_file_to_path(path: String, data: Vec<u8>) -> Result<(), String> {
     Ok(())
 }
 
+#[tauri::command]
+fn copy_file_from_storage(
+    app: tauri::AppHandle,
+    relative_path: String,
+    dest_path: String,
+) -> Result<(), String> {
+    use std::fs;
+    let app_data_dir = app.path().app_data_dir().map_err(|e| e.to_string())?;
+    let src_path = app_data_dir.join(&relative_path);
+    if !src_path.exists() {
+        return Err(format!("Source file does not exist: {:?}", src_path));
+    }
+    fs::copy(&src_path, &dest_path).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -109,7 +125,11 @@ pub fn run() {
 
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![get_backend_port, save_file_to_path])
+        .invoke_handler(tauri::generate_handler![
+            get_backend_port,
+            save_file_to_path,
+            copy_file_from_storage
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
Passes resolvedUrl directly to Rust backend to execute filesystem copies, avoiding heavy payload serializations over WebView IPC, and removes port caching to prevent race conditions during dynamic sidecar startup.