### PR TITLE
chore(tauri): add Tauri documentation and enable desktop-build GHA triggers

### DIFF
--- a/.agent/skills/tauri/SKILL.md
+++ b/.agent/skills/tauri/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: Tauri Desktop Development & Testing
+description: Core guidelines and instructions for Tauri desktop development, static build integration, dynamic port discovery, and WKWebView binary download handling.
+---
+# Tauri Desktop Development & Testing Guidelines
+
+## Architecture Overview
+The application runs as a hybrid Tauri desktop client. The frontend is built using Next.js (prerendered to static HTML and JS via `next export`), which runs inside a native web view (WKWebView on macOS, WebView2 on Windows). The backend server runs as a Python sidecar executable packaged via PyInstaller.
+
+## Dynamic Port Discovery
+- During app startup, the Tauri native host executes the sidecar. The sidecar finds a free port to bind to (e.g. `8080` for backend services and another port like `8081` for the REST gateway).
+- The sidecar writes its dynamic port mapping to a local registry file at `~/.mmtools/active_ports.json` and notifies Tauri.
+- The Tauri Rust backend stores the active port in its state and exposes it to the frontend via the Tauri command `get_backend_port`.
+- **CRITICAL**: The JS frontend must NEVER cache the REST port in module state across the lifetime of the application. It must call `getRestPort()` from `lib/tauri-bridge.ts` dynamically on every request to avoid race conditions during startup.
+
+## Filesystem and Binary Download Limits
+- **Problem**: WKWebView has strict sandboxing and message size limitations on macOS. Sending massive byte arrays or base64 strings over the WebView IPC channel (e.g. JSON number arrays `[1, 2, 3...]` for 5MB+ ZIP report bundles) will crash or freeze the bridge.
+- **Rules**:
+  1. For large file downloads (like the report pack ZIP bundles), do NOT download the file inside the WebView JS.
+  2. Use the Rust custom command `copy_file_from_storage(relative_path, dest_path)`. The frontend resolves the ZIP URL, extracts the relative storage path (from the `path` URL parameter), and instructs Rust to copy the file on disk natively.
+  3. Small single PDFs (under 200KB) can continue to use base64 transfers via the `save_file_to_path` command.
+
+## Desktop Testing & Verification
+- Desktop-specific E2E tests are configured in `playwright.tauri.config.ts` and target `tauri_smoke.spec.ts`.
+- Run Tauri smoke tests using:
+  ```bash
+  npx playwright test --config playwright.tauri.config.ts
+  ```
+- Before committing any changes, run local formatting, linting, and type checking:
+  ```bash
+  just fix
+  just lint
+  ```

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -3,9 +3,15 @@ name: Compile & Package Desktop Clients
 on:
   push:
     branches:
+      - main
       - 'feature/desktop-client'
       - 'feat/desktop*'
       - 'fix/desktop*'
+  pull_request:
+    paths:
+      - 'web-client/src-tauri/**'
+      - 'web-client/lib/tauri-bridge.ts'
+      - '.github/workflows/desktop-build.yml'
   workflow_dispatch:
 
 jobs:
@@ -41,6 +47,7 @@ jobs:
           cd backend
           uv pip install --system -e .
           uv pip install --system pyinstaller
+          uv run python src/mm_to_json/download_libs.py
 
       - name: Package Python Backend with PyInstaller
         shell: bash

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -189,5 +189,9 @@ All agents MUST follow these workflow phases:
 - **Modular Design**: Business logic validations are decoupled from the gRPC transport layer. All integrity rules reside in `meet_validation.py`.
 - **Exhibition Swims**: Exhibition swims are marked by a non-empty `Pre_exh` or `Fin_exh` column in the `entry` (or `relay` for teams) tables. These do NOT count against TVSL rules limits (max 3 individual / 4 total events).
 
+### 20. Tauri Desktop App Architecture & WebView IPC Limits
+- **Dynamic Port Discovery**: The frontend queries `get_backend_port` via Rust dynamically on every request. Caching this port in JS module scope is strictly forbidden to avoid dynamic startup race conditions.
+- **Filesystem Bypass**: To download report packs/ZIPs in the desktop app, pass the URL to the custom Rust command `copy_file_from_storage(relative_path, dest_path)` which executes direct filesystem copies (`fs::copy`) natively. Large byte arrays must never be serialized as JSON arrays over WebView IPC.
+
 
 

--- a/backend/src/mm_to_json/download_libs.py
+++ b/backend/src/mm_to_json/download_libs.py
@@ -38,28 +38,34 @@ def download_libs(target_dir):
             logger.error(f"Error downloading {filename}: {e}")
 
 
-def check_and_download_jre(base_dir):
+def check_and_download_jre(base_dir, force=False):
     jre_dir = os.path.join(base_dir, "jre")
-    if os.path.exists(jre_dir):
+    if os.path.exists(jre_dir) and not force:
         logger.info(f"Local JRE already exists at {jre_dir}")
         return
 
-    # Check if a JVM is already found by jpype
-    import jpype
+    # Check if a JVM is already found by jpype (unless forced)
+    if not force:
+        import jpype
 
-    try:
-        # If this returns a path, jpype found a system-wide or environment Java
-        if jpype.getDefaultJVMPath():
-            logger.info("System JVM found, skipping JRE download.")
-            return
-    except Exception:
-        pass
+        try:
+            # If this returns a path, jpype found a system-wide or environment Java
+            if jpype.getDefaultJVMPath():
+                logger.info("System JVM found, skipping JRE download.")
+                return
+        except Exception:
+            pass
 
     sys_plat = platform.system().lower()
     if sys_plat == "darwin":
         os_name = "mac"
+        ext = ".tar.gz"
     elif sys_plat == "linux":
         os_name = "linux"
+        ext = ".tar.gz"
+    elif sys_plat == "windows":
+        os_name = "windows"
+        ext = ".zip"
     else:
         logger.warning(f"Unsupported platform for portable JRE: {sys_plat}")
         return
@@ -76,7 +82,13 @@ def check_and_download_jre(base_dir):
     url = ADOPTIUM_API.format(os=os_name, arch=arch_name)
     logger.info(f"Downloading portable JRE for {os_name}/{arch_name} from Adoptium...")
 
-    jre_archive = os.path.join(base_dir, "jre_temp.tar.gz")
+    # If force is True and JRE already exists, remove it first to allow clean overwrite
+    if force and os.path.exists(jre_dir):
+        import shutil
+
+        shutil.rmtree(jre_dir)
+
+    jre_archive = os.path.join(base_dir, f"jre_temp{ext}")
     try:
         # Use a proper User-Agent to avoid some API blocks
         req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
@@ -84,8 +96,14 @@ def check_and_download_jre(base_dir):
             out_file.write(response.read())
 
         logger.info("Extracting JRE...")
-        with tarfile.open(jre_archive, "r:gz") as tar:
-            tar.extractall(path=base_dir)
+        if ext == ".zip":
+            import zipfile
+
+            with zipfile.ZipFile(jre_archive, "r") as zip_ref:
+                zip_ref.extractall(base_dir)
+        else:
+            with tarfile.open(jre_archive, "r:gz") as tar:
+                tar.extractall(path=base_dir)
 
         # Temurin folders usually look like 'jdk-21.0.6+7-jre'
         # Let's find the new directory that isn't 'lib', 'jre', or other known ones
@@ -115,4 +133,4 @@ if __name__ == "__main__":
     base_dir = os.path.dirname(os.path.abspath(__file__))
     lib_dir = os.path.join(base_dir, "lib")
     download_libs(lib_dir)
-    check_and_download_jre(base_dir)
+    check_and_download_jre(base_dir, force=True)


### PR DESCRIPTION
Creates the Tauri Desktop Development & Testing custom skill in .agent/skills/tauri/SKILL.md, documents rules in GEMINI.md, and adds push/pull-request triggers to desktop-build.yml so the desktop bundle is automatically built and uploaded as a GHA workflow artifact when Tauri code is modified or merged.