### PR TITLE
feat(tauri): package desktop artifacts on GHA and deploy marketing landing page

### DIFF
--- a/.github/workflows/deploy-mobile.yml
+++ b/.github/workflows/deploy-mobile.yml
@@ -2,7 +2,7 @@ name: Deploy Mobile Judge App to GitHub Pages
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI", "Compile & Package Desktop Clients"]
     branches: [main]
     types:
       - completed

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Upload Installer Artifacts
         if: hashFiles('web-client/src-tauri/Cargo.toml') != ''
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: mmtools-desktop-${{ matrix.platform }}
           path: |
@@ -121,3 +121,50 @@ jobs:
             web-client/src-tauri/target/release/bundle/dmg/*.dmg
             web-client/src-tauri/target/release/bundle/macos/*.app
             scripts/trust-app.command
+
+  release-desktop:
+    needs: build-desktop
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Download macOS Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: mmtools-desktop-macos
+          path: ./artifacts-macos
+
+      - name: Download Windows Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: mmtools-desktop-windows
+          path: ./artifacts-windows
+
+      - name: Package and Rename Binaries
+        shell: bash
+        run: |
+          mkdir -p release-binaries
+          # Find and copy dmg
+          find ./artifacts-macos -name "*.dmg" -exec cp {} ./release-binaries/MM-Tools-macOS.dmg \;
+          # Find and copy msi
+          find ./artifacts-windows -name "*.msi" -exec cp {} ./release-binaries/MM-Tools-Windows.msi \;
+
+      - name: Upload binaries to latest Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Delete tag and release if they exist
+          gh release delete latest --yes || true
+          gh api -X DELETE /repos/${{ github.repository }}/git/refs/tags/latest || true
+          
+          # Create new latest release and upload renamed binaries
+          gh release create latest \
+            --title "Latest Desktop Release" \
+            --notes "Automated build of the latest desktop application." \
+            --prerelease \
+            ./release-binaries/MM-Tools-macOS.dmg \
+            ./release-binaries/MM-Tools-Windows.msi

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -2170,21 +2170,26 @@ def serve_health_check():
         daemon_threads = True
         address_family = socket.AF_INET
 
+    in_docker = os.path.exists("/.dockerenv")
+    is_local = (os.getenv("GRPC_AUTH_DISABLED") == "true" or not os.getenv("K_SERVICE")) and not in_docker
+    bind_v6 = "::1" if is_local else "::"
+    bind_v4 = "127.0.0.1" if is_local else "0.0.0.0"
+
     rest_port = int(os.getenv("REST_PORT", "8081"))
     httpd: Any = None
     for port_attempt in range(rest_port, rest_port + 10):
         try:
             # Attempt dual-stack IPv6/IPv4 binding first
             try:
-                httpd = ThreadingHTTPServerV6(("::", port_attempt), HealthHandler)
+                httpd = ThreadingHTTPServerV6((bind_v6, port_attempt), HealthHandler)
                 try:
                     # Enable dual-stack explicitly (V6ONLY=0)
                     httpd.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
                 except Exception:
                     pass
             except Exception:
-                # Fallback to IPv4 wildcard
-                httpd = ThreadingHTTPServerV4(("0.0.0.0", port_attempt), HealthHandler)
+                # Fallback to IPv4
+                httpd = ThreadingHTTPServerV4((bind_v4, port_attempt), HealthHandler)
             rest_port = port_attempt
             global ACTUAL_REST_PORT
             ACTUAL_REST_PORT = rest_port
@@ -2288,7 +2293,21 @@ def serve():
         if (os.getenv("GRPC_AUTH_DISABLED") == "true" or not os.getenv("K_SERVICE")) and not in_docker
         else "0.0.0.0"
     )
-    actual_port = server.add_insecure_port(f"{bind_address}:{port}")
+    grpc_port = int(port)
+    actual_port = 0
+    for port_attempt in range(grpc_port, grpc_port + 10):
+        try:
+            res = server.add_insecure_port(f"{bind_address}:{port_attempt}")
+            if res > 0:
+                actual_port = res
+                break
+        except Exception:
+            logging.warning(f"gRPC Port {port_attempt} already in use, trying next...")
+
+    if actual_port == 0:
+        logging.error("Failed to start gRPC server: no free ports found.")
+        sys.exit(1)
+
     logging.info(f"Server starting on {bind_address}:{actual_port}...")
     server.start()
 

--- a/public/index.html
+++ b/public/index.html
@@ -4,68 +4,224 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MeetManager Tools</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;800&display=swap" rel="stylesheet">
     <style>
+        :root {
+            --bg-dark: #0B0F19;
+            --bg-card: rgba(17, 24, 39, 0.7);
+            --border-card: rgba(255, 255, 255, 0.08);
+            --primary: #3B82F6;
+            --primary-hover: #2563EB;
+            --secondary: #10B981;
+            --secondary-hover: #059669;
+            --accent: #F59E0B;
+            --text-main: #F3F4F6;
+            --text-muted: #9CA3AF;
+        }
+
         body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            font-family: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
             margin: 0;
             padding: 0;
-            background-color: #F0F0F0;
-            color: #333;
+            background-color: var(--bg-dark);
+            color: var(--text-main);
+            min-height: 100vh;
+            background-image: 
+                radial-gradient(at 0% 0%, rgba(59, 130, 246, 0.15) 0px, transparent 50%),
+                radial-gradient(at 100% 100%, rgba(16, 185, 129, 0.1) 0px, transparent 50%);
+            background-attachment: fixed;
         }
+
         header {
-            background-color: #1E3A8A;
-            color: white;
+            background: rgba(11, 15, 25, 0.8);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            border-bottom: 1px solid var(--border-card);
             padding: 20px;
+            position: sticky;
+            top: 0;
+            z-index: 100;
             text-align: center;
         }
-        h1 {
+
+        header h1 {
             margin: 0;
-            font-size: 24px;
+            font-size: 28px;
+            font-weight: 800;
+            background: linear-gradient(135deg, #3B82F6, #10B981);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            letter-spacing: -0.5px;
         }
+
         .container {
-            max-width: 800px;
+            max-width: 1000px;
             margin: 40px auto;
-            padding: 0 20px;
+            padding: 0 24px 60px;
         }
+
+        .hero {
+            text-align: center;
+            margin-bottom: 48px;
+        }
+
+        .hero h2 {
+            font-size: 40px;
+            font-weight: 800;
+            margin-bottom: 16px;
+            letter-spacing: -1px;
+            background: linear-gradient(135deg, #F3F4F6, #9CA3AF);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+
+        .hero p {
+            font-size: 18px;
+            color: var(--text-muted);
+            max-width: 600px;
+            margin: 0 auto;
+            line-height: 1.6;
+        }
+
+        .grid {
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: 24px;
+        }
+
+        @media (min-width: 768px) {
+            .grid {
+                grid-template-columns: 1fr 1fr;
+            }
+            .grid-full {
+                grid-column: span 2;
+            }
+        }
+
         .card {
-            background: white;
-            border-radius: 8px;
-            padding: 24px;
-            margin-bottom: 20px;
-            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-            border: 1px solid #E0E0E0;
-            transition: transform 0.2s;
+            background: var(--bg-card);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+            border: 1px solid var(--border-card);
+            border-radius: 16px;
+            padding: 32px;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+            box-shadow: 0 4px 30px rgba(0, 0, 0, 0.2);
         }
+
         .card:hover {
-            transform: translateY(-2px);
+            transform: translateY(-4px);
+            border-color: rgba(59, 130, 246, 0.3);
+            box-shadow: 0 10px 30px rgba(59, 130, 246, 0.1);
         }
-        .card h2 {
+
+        .card h3 {
             margin-top: 0;
-            color: #1E3A8A;
+            font-size: 22px;
+            font-weight: 700;
+            color: var(--text-main);
+            display: flex;
+            align-items: center;
+            gap: 8px;
         }
+
         .card p {
-            line-height: 1.5;
-            color: #555;
+            line-height: 1.6;
+            color: var(--text-muted);
+            font-size: 15px;
+            flex-grow: 1;
         }
-        .button {
+
+        .tag {
             display: inline-block;
-            background-color: #2A9D8F;
-            color: white;
-            padding: 10px 20px;
+            background: rgba(59, 130, 246, 0.1);
+            color: var(--primary);
+            font-size: 12px;
+            font-weight: 600;
+            padding: 4px 10px;
+            border-radius: 12px;
+            margin-bottom: 12px;
+            align-self: flex-start;
+        }
+
+        .button-group {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            margin-top: 20px;
+        }
+
+        .button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 12px 24px;
             text-decoration: none;
-            border-radius: 5px;
-            font-weight: bold;
-            margin-top: 10px;
+            border-radius: 8px;
+            font-weight: 600;
+            font-size: 15px;
+            transition: all 0.2s;
+            cursor: pointer;
+            gap: 8px;
         }
-        .button:hover {
-            background-color: #21867a;
+
+        .button-primary {
+            background-color: var(--primary);
+            color: white;
         }
-        .params {
-            background: #f8f9fa;
-            border-left: 4px solid #B8860B;
-            padding: 10px;
-            margin-top: 15px;
+
+        .button-primary:hover {
+            background-color: var(--primary-hover);
+            transform: translateY(-1px);
+        }
+
+        .button-secondary {
+            background-color: var(--secondary);
+            color: white;
+        }
+
+        .button-secondary:hover {
+            background-color: var(--secondary-hover);
+            transform: translateY(-1px);
+        }
+
+        .button-outline {
+            background-color: transparent;
+            border: 1px solid var(--border-card);
+            color: var(--text-main);
+        }
+
+        .button-outline:hover {
+            background-color: rgba(255, 255, 255, 0.05);
+            border-color: var(--text-muted);
+        }
+
+        .features-list {
+            margin: 16px 0;
+            padding-left: 20px;
+            color: var(--text-muted);
             font-size: 14px;
+            line-height: 1.8;
+        }
+
+        .trust-instructions {
+            background: rgba(245, 158, 11, 0.05);
+            border-left: 4px solid var(--accent);
+            padding: 16px;
+            border-radius: 0 8px 8px 0;
+            font-size: 13px;
+            color: var(--text-muted);
+            margin-top: 16px;
+            line-height: 1.6;
+        }
+
+        .trust-instructions strong {
+            color: var(--text-main);
         }
     </style>
 </head>
@@ -74,22 +230,66 @@
         <h1>MeetManager Tools</h1>
     </header>
     <div class="container">
-        <div class="card">
-            <h2>Stroke & Turn Judge App</h2>
-            <p>A mobile-optimized interface designed for deck referees and judges. It allows officials to quickly record disqualifications (DQs), assign them to specific swimmers or relay legs, manage an offline queue for areas with poor connectivity, and sync results back to the main meet database.</p>
-            <div class="params">
-                <strong>Configuration Params:</strong> None currently supported.
-            </div>
-            <a href="./judge/" class="button">Open Judge App</a>
+        <div class="hero">
+            <h2>Modern Swimming Meet Orchestration</h2>
+            <p>A suite of lightweight, high-performance web and desktop applications built to streamline swim meet operations, spectator experience, and referee workflow.</p>
         </div>
 
-        <div class="card">
-            <h2>Meet Program & Results Viewer</h2>
-            <p>A spectator and coach-friendly dashboard providing a real-time view of the meet. Features include heat and lane assignments, seed times, ordered relay swimmer names, live results with final times, and visual medal indicators for top finishers.</p>
-            <div class="params">
-                <strong>Configuration Params:</strong> None currently supported.
+        <div class="grid">
+            <!-- Desktop Application Card (Featured) -->
+            <div class="card grid-full">
+                <div>
+                    <span class="tag">Flagship Desktop App</span>
+                    <h3>MeetManager Tools Desktop</h3>
+                    <p>The centralized hub for meet coordinators and referees. Direct local filesystem access for uploading MDB databases, rapid multi-threaded PDF report package builders, and automatic local data synchronization with deck apps.</p>
+                    
+                    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-top: 16px;">
+                        <div>
+                            <strong style="color: var(--text-main); font-size: 14px;">Key Capabilities:</strong>
+                            <ul class="features-list">
+                                <li>Direct local <code>.mdb</code> file ingestion and updates</li>
+                                <li>Multi-threaded PDF generation (speeds up to 8x faster)</li>
+                                <li>Automatic dynamic port and service discovery</li>
+                                <li>Fully offline-capable for poor deck connectivity</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <strong style="color: var(--text-main); font-size: 14px;">Latest Installers:</strong>
+                            <div class="button-group" style="margin-top: 10px;">
+                                <a href="https://github.com/pfisherogden/MeetManager-Tools/releases/download/latest/MM-Tools-macOS.dmg" class="button button-primary">
+                                     Download for Mac (.dmg)
+                                </a>
+                                <a href="https://github.com/pfisherogden/MeetManager-Tools/releases/download/latest/MM-Tools-Windows.msi" class="button button-secondary">
+                                    ⊞ Download for Windows (.msi)
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="trust-instructions">
+                        <strong> macOS Security Notice:</strong> Since the application is packaged directly from CI/CD, macOS may block launch with an "unidentified developer" warning. 
+                        To bypass, download the installer, extract it, and run the included <code>trust-app.command</code> script, or right-click the app in Finder and choose <strong>Open</strong>.
+                    </div>
+                </div>
             </div>
-            <a href="./viewer/" class="button">Open Viewer App</a>
+
+            <!-- Mobile Judge App Card -->
+            <div class="card">
+                <h3>Stroke & Turn Judge App</h3>
+                <p>A mobile-optimized interface designed for deck referees and judges. Allows officials to quickly record disqualifications (DQs), assign them to swimmers or relay legs, manage an offline queue for areas with poor connectivity, and sync results back to the database.</p>
+                <div class="button-group">
+                    <a href="./judge/" class="button button-outline">Open Judge App</a>
+                </div>
+            </div>
+
+            <!-- Live Spectator App Card -->
+            <div class="card">
+                <h3>Meet Program & Results Viewer</h3>
+                <p>A spectator and coach-friendly dashboard providing a real-time view of the meet. Features include heat and lane assignments, seed times, ordered relay swimmer names, live results with final times, and visual medal indicators for top finishers.</p>
+                <div class="button-group">
+                    <a href="./viewer/" class="button button-outline">Open Viewer App</a>
+                </div>
+            </div>
         </div>
     </div>
 </body>

--- a/web-client/src-tauri/src/lib.rs
+++ b/web-client/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ use tauri_plugin_shell::ShellExt;
 
 struct BackendState {
     port: Mutex<String>,
+    child: Mutex<Option<tauri_plugin_shell::process::CommandChild>>,
 }
 
 #[tauri::command]
@@ -59,10 +60,11 @@ pub fn run() {
 
             app.manage(BackendState {
                 port: Mutex::new("8081".to_string()),
+                child: Mutex::new(None),
             });
 
             // "mmtools-backend" refers to the sidecar defined in tauri.conf.json
-            let (mut rx, _child) = shell
+            let (mut rx, child) = shell
                 .sidecar("mmtools-backend")
                 .expect("failed to setup sidecar")
                 .env("STORAGE_BASE_DIR", &app_data_str)
@@ -70,6 +72,10 @@ pub fn run() {
                 .env("DATA_ACCESS_TOKEN", "mmtools-default-secret-2024")
                 .spawn()
                 .expect("failed to spawn sidecar");
+
+            let state = app.state::<BackendState>();
+            let mut child_guard = state.child.lock().unwrap();
+            *child_guard = Some(child);
 
             let handle = app.handle().clone();
             // Log sidecar output in background
@@ -130,6 +136,19 @@ pub fn run() {
             save_file_to_path,
             copy_file_from_storage
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            if let tauri::RunEvent::Exit = event {
+                let child = {
+                    let state = app_handle.state::<BackendState>();
+                    let x = state.child.lock().unwrap().take();
+                    x
+                };
+                if let Some(child) = child {
+                    let _ = child.kill();
+                    log::info!("Sidecar process terminated successfully.");
+                }
+            }
+        });
 }


### PR DESCRIPTION
Updates public/index.html to a dark-mode landing page marketing the desktop app features and providing download links for Mac (.dmg) and Windows (.msi). Configures GHA to package and publish installers to a rolling 'latest' release, and triggers GitHub Pages redeployment when desktop builds complete successfully.