### PR TITLE
fix(backend): resolve local JVM path on Windows platform

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'web-client/src-tauri/**'
       - 'web-client/lib/tauri-bridge.ts'
+      - 'backend/src/**'
       - '.github/workflows/desktop-build.yml'
   workflow_dispatch:
 

--- a/backend/src/mm_to_json/mdb_writer.py
+++ b/backend/src/mm_to_json/mdb_writer.py
@@ -15,6 +15,27 @@ def get_classpath():
     return jars
 
 
+def get_potential_jvm_paths(local_jre: str, system: str) -> list[str]:
+    """Returns a list of potential paths to the JVM library inside a local JRE folder."""
+    potentials = []
+    if system == "Darwin":
+        potentials = [
+            os.path.join(local_jre, "Contents", "Home", "lib", "server", "libjvm.dylib"),
+            os.path.join(local_jre, "lib", "server", "libjvm.dylib"),
+        ]
+    elif system == "Windows":
+        potentials = [
+            os.path.join(local_jre, "bin", "server", "jvm.dll"),
+            os.path.join(local_jre, "bin", "client", "jvm.dll"),
+        ]
+    else:
+        potentials = [
+            os.path.join(local_jre, "lib", "server", "libjvm.so"),
+            os.path.join(local_jre, "lib", "client", "libjvm.so"),
+        ]
+    return potentials
+
+
 def ensure_jvm_started():
     """Starts the JVM if not already started."""
     if jpype.isJVMStarted():
@@ -29,18 +50,16 @@ def ensure_jvm_started():
     base_dir = os.path.dirname(os.path.abspath(__file__))
     local_jre = os.path.join(base_dir, "jre")
     if os.path.exists(local_jre):
-        # macOS Corretto location: jre/Contents/Home/lib/server/libjvm.dylib
-        # Linux Corretto location: jre/lib/server/libjvm.so
         import platform
 
-        if platform.system() == "Darwin":
-            potential = os.path.join(local_jre, "Contents", "Home", "lib", "server", "libjvm.dylib")
-        else:
-            potential = os.path.join(local_jre, "lib", "server", "libjvm.so")
+        system = platform.system()
+        potentials = get_potential_jvm_paths(local_jre, system)
 
-        if os.path.exists(potential):
-            jvm_path = potential
-            logger.debug(f"Using local JRE at {jvm_path}")
+        for potential in potentials:
+            if os.path.exists(potential):
+                jvm_path = potential
+                logger.debug(f"Using local JRE at {jvm_path}")
+                break
 
     # 2. Fallback to system default if no local JRE
     if not jvm_path:

--- a/backend/tests/test_jvm_resolution.py
+++ b/backend/tests/test_jvm_resolution.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+
+from mm_to_json.mdb_writer import get_potential_jvm_paths
+
+
+def test_get_potential_jvm_paths():
+    local_jre = os.path.join("fake", "path", "jre")
+
+    # 1. Darwin/macOS
+    darwin_paths = get_potential_jvm_paths(local_jre, "Darwin")
+    assert any("libjvm.dylib" in p for p in darwin_paths)
+    assert any("Contents" in p for p in darwin_paths)
+
+    # 2. Windows
+    windows_paths = get_potential_jvm_paths(local_jre, "Windows")
+    assert any("jvm.dll" in p for p in windows_paths)
+    assert any("bin" in p for p in windows_paths)
+
+    # 3. Linux/Other
+    linux_paths = get_potential_jvm_paths(local_jre, "Linux")
+    assert any("libjvm.so" in p for p in linux_paths)
+    assert any("lib" in p for p in linux_paths)

--- a/public/index.html
+++ b/public/index.html
@@ -268,8 +268,23 @@
                     </div>
 
                     <div class="trust-instructions">
-                        <strong> macOS Installation Note:</strong> Since the application is compiled and packaged securely via GitHub Actions, macOS might warn about an "unidentified developer" on first launch. 
-                        To run the app, simply download the installer, open it, and right-click the MMTools app icon, then select <strong>Open</strong> from the context menu to authorize it.
+                        <strong> macOS Installation Note:</strong> Since the application is compiled and packaged securely via GitHub Actions, macOS will show an "unidentified developer" warning on first launch. You can authorize <strong>only this specific app</strong> without changing your Mac's global security settings using one of these methods:
+                        <div style="margin-top: 10px;">
+                            <strong>Method 1: Open Anyway (Standard)</strong>
+                            <ol style="margin: 4px 0 12px 20px; padding: 0; font-size: 13px; color: var(--text-muted); line-height: 1.6;">
+                                <li>Double-click the downloaded app to trigger the warning dialog, then click <strong>Cancel</strong>.</li>
+                                <li>Open your Mac's <strong>System Settings</strong> and navigate to <strong>Privacy & Security</strong>.</li>
+                                <li>Scroll down to the <strong>Security</strong> section. You will see a note stating: <em>"MM-Tools" was blocked from use because it is not from an identified developer</em>.</li>
+                                <li>Click the <strong>Open Anyway</strong> button and enter your Mac credentials. This authorizes only MMTools.</li>
+                            </ol>
+                        </div>
+                        <div>
+                            <strong>Method 2: Remove Quarantine Flag (Terminal)</strong>
+                            <p style="margin: 4px 0 0 0; font-size: 13px; color: var(--text-muted); line-height: 1.6;">
+                                Alternatively, you can clear the download quarantine flag for MMTools alone. Open your Terminal and run:
+                                <code style="display: block; background: rgba(0,0,0,0.3); padding: 8px; border-radius: 4px; margin-top: 6px; font-family: monospace; color: var(--accent);">xattr -d com.apple.quarantine /Applications/MM-Tools.app</code>
+                            </p>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Updates local JRE detection logic in mdb_writer.py to support Windows directory layout and file extensions (bin/server/jvm.dll), allowing MDB files to be parsed offline on Windows without a pre-installed system JRE. Resolves issue #557.