### PR TITLE
Fix Windows compatibility issues (PyInstaller, strftime, path separators, tempfile locking)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -54,7 +54,11 @@ jobs:
         shell: bash
         run: |
           cd backend
-          pyinstaller --onefile --add-data "data/Sample_Data.json:data" --add-data "src/mm_to_json/jre:mm_to_json/jre" --add-data "src/mm_to_json/lib:mm_to_json/lib" --add-data "src/mm_to_json/reporting/templates:mm_to_json/reporting/templates" --name ${{ matrix.output_name }} src/server.py
+          if [ "${{ matrix.platform }}" = "windows-latest" ]; then
+            pyinstaller --onefile --add-data "data/Sample_Data.json;data" --add-data "src/mm_to_json/jre;mm_to_json/jre" --add-data "src/mm_to_json/lib;mm_to_json/lib" --add-data "src/mm_to_json/reporting/templates;mm_to_json/reporting/templates" --name ${{ matrix.output_name }} src/server.py
+          else
+            pyinstaller --onefile --add-data "data/Sample_Data.json:data" --add-data "src/mm_to_json/jre:mm_to_json/jre" --add-data "src/mm_to_json/lib:mm_to_json/lib" --add-data "src/mm_to_json/reporting/templates:mm_to_json/reporting/templates" --name ${{ matrix.output_name }} src/server.py
+          fi
           
           # Move output to Tauri's sidecars directory in web-client if it exists
           if [ -d "../web-client/src-tauri" ]; then

--- a/backend/src/handlers/report_handler.py
+++ b/backend/src/handlers/report_handler.py
@@ -244,12 +244,16 @@ def _process_single_report_process(
                 except Exception as e:
                     logging.warning(f"Google Sheet generation failed, but will still provide Excel backup: {e}")
 
-            with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as xlsx_tmp:
+            xlsx_tmp = tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False)
+            xlsx_tmp.close()
+            try:
                 excel_writer = SwimmerCheckInWriter(check_in_data, title=title)
                 excel_writer.generate_excel_backup(xlsx_tmp.name)
                 with open(xlsx_tmp.name, "rb") as f_read:
                     content = f_read.read()
-                os.unlink(xlsx_tmp.name)
+            finally:
+                if os.path.exists(xlsx_tmp.name):
+                    os.unlink(xlsx_tmp.name)
 
             res_files = []
             filename = f"{title.replace(' ', '_')}_{idx}.xlsx" if title else f"check_in_{idx}.xlsx"
@@ -257,12 +261,16 @@ def _process_single_report_process(
 
             if gs_url:
                 shortcut_name = f"OPEN_GOOGLE_SHEET_{filename.replace('.xlsx', '.html')}"
-                with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as html_tmp:
+                html_tmp = tempfile.NamedTemporaryFile(suffix=".html", delete=False)
+                html_tmp.close()
+                try:
                     shortcut_writer = SwimmerCheckInWriter(check_in_data, title=title)
                     shortcut_writer.generate_google_sheet_shortcut(gs_url, html_tmp.name)
                     with open(html_tmp.name, "rb") as f_read:
                         shortcut_content = f_read.read()
-                    os.unlink(html_tmp.name)
+                finally:
+                    if os.path.exists(html_tmp.name):
+                        os.unlink(html_tmp.name)
                 res_files.append({"filename": shortcut_name, "content": shortcut_content})
 
             return {

--- a/backend/src/mm_to_json/reporting/playwright_renderer.py
+++ b/backend/src/mm_to_json/reporting/playwright_renderer.py
@@ -32,7 +32,8 @@ class PlaywrightRenderer:
 
         tz = pytz.timezone("America/Los_Angeles")
         # Format like MM: "2:17 PM 5/29/2026"
-        render_data["generation_time"] = datetime.datetime.now(tz).strftime("%-I:%M %p %-m/%-d/%Y")
+        fmt = "%#I:%M %p %#m/%#d/%Y" if os.name == "nt" else "%-I:%M %p %-m/%-d/%Y"
+        render_data["generation_time"] = datetime.datetime.now(tz).strftime(fmt)
 
         return template.render(**render_data)
 
@@ -53,7 +54,8 @@ class PlaywrightRenderer:
             display_meet = meet_name or "Meet Manager Tools"
 
             tz = pytz.timezone("America/Los_Angeles")
-            gen_time = datetime.datetime.now(tz).strftime("%-I:%M %p %-m/%-d/%Y")
+            fmt = "%#I:%M %p %#m/%#d/%Y" if os.name == "nt" else "%-I:%M %p %-m/%-d/%Y"
+            gen_time = datetime.datetime.now(tz).strftime(fmt)
 
             header_html = f"""
             <div style="font-family: Helvetica, Arial, sans-serif; font-size: 8pt; width: 100%; margin: 0 0.5in; border-bottom: 0.5pt solid #000; padding-top: 0.4in; padding-bottom: 3pt;">

--- a/backend/src/mm_to_json/reporting/weasy_renderer.py
+++ b/backend/src/mm_to_json/reporting/weasy_renderer.py
@@ -32,8 +32,9 @@ class WeasyRenderer:
 
         tz = pytz.timezone("America/Los_Angeles")
         # Format like MM: "2:17 PM 5/29/2026"
-        # %-m and %-d remove leading zeros on Linux/Unix
-        render_data["generation_time"] = datetime.datetime.now(tz).strftime("%-I:%M %p %-m/%-d/%Y")
+        # %-m and %-d remove leading zeros on Linux/Unix, %#I, %#m, %#d on Windows (MSVC)
+        fmt = "%#I:%M %p %#m/%#d/%Y" if os.name == "nt" else "%-I:%M %p %-m/%-d/%Y"
+        render_data["generation_time"] = datetime.datetime.now(tz).strftime(fmt)
 
         return template.render(**render_data)
 

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -610,8 +610,9 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
         """Masks sensitive parts of a path for safe logging."""
         if not path:
             return ""
-        if path.startswith("users/"):
-            parts = path.split("/")
+        normalized_path = path.replace("\\", "/")
+        if normalized_path.startswith("users/"):
+            parts = normalized_path.split("/")
             if len(parts) > 1:
                 uid = parts[1]
                 masked_uid = self._mask_uid(uid)
@@ -994,7 +995,8 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
             for rel_path in files:
                 # ONLY allow files in the root user directory (not subdirs like 'published/' or 'bundles/')
                 # rel_path looks like "users/UID/filename.ext" or "users/UID/published/file.json"
-                parts = rel_path.split("/")
+                normalized_path = rel_path.replace("\\", "/")
+                parts = normalized_path.split("/")
                 if len(parts) != 3:
                     continue
 

--- a/backend/src/storage_provider.py
+++ b/backend/src/storage_provider.py
@@ -9,8 +9,9 @@ logger = logging.getLogger(__name__)
 class StorageProvider(ABC):
     def _sanitize_path(self, path: str) -> str:
         """Masks sensitive parts of the path (e.g. UIDs)."""
-        if path.startswith("users/"):
-            parts = path.split("/")
+        normalized_path = path.replace("\\", "/")
+        if normalized_path.startswith("users/"):
+            parts = normalized_path.split("/")
             if len(parts) > 1:
                 uid = parts[1]
                 masked_uid = f"{uid[:4]}...{uid[-4:]}" if len(uid) > 8 else "***"
@@ -72,7 +73,7 @@ class LocalStorageProvider(StorageProvider):
         for root, _, filenames in os.walk(full_prefix_path):
             for filename in filenames:
                 rel_path = os.path.relpath(os.path.join(root, filename), self.base_dir)
-                files.append(rel_path)
+                files.append(rel_path.replace("\\", "/"))
         logger.debug(f"LocalStorageProvider: found {len(files)} files")
         return files
 

--- a/backend/tests/test_windows_compatibility.py
+++ b/backend/tests/test_windows_compatibility.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import datetime
+import os
+
+import pytz
+
+
+def test_windows_format_string():
+    # Verify that the standard strftime format string is safe on the current platform
+    tz = pytz.timezone("America/Los_Angeles")
+    now = datetime.datetime.now(tz)
+
+    # Detect platform-safe strftime format string
+    fmt = "%#I:%M %p %#m/%#d/%Y" if os.name == "nt" else "%-I:%M %p %-m/%-d/%Y"
+    try:
+        gen_time = now.strftime(fmt)
+        assert len(gen_time) > 0
+    except ValueError as e:
+        raise AssertionError(f"Format string '{fmt}' is invalid on {os.name}: {e}") from e
+
+
+def test_path_normalization_list_datasets():
+    # Simulate Windows backslash path list
+    windows_paths = [
+        "users\\e2e-default-user\\config.json",
+        "users\\e2e-default-user\\Singers23.mdb",
+    ]
+
+    # Verify that normalizing paths to forward slashes resolves path components correctly
+    parsed_files = []
+    for rel_path in windows_paths:
+        normalized_path = rel_path.replace("\\", "/")
+        parts = normalized_path.split("/")
+        if len(parts) == 3:
+            parsed_files.append(parts[2])
+
+    assert "Singers23.mdb" in parsed_files
+    assert "config.json" in parsed_files


### PR DESCRIPTION
Closes #559. Fixes compatibility bugs blocking the Windows desktop application:
1. PyInstaller separator: Use ';' path separator in desktop-build.yml when packaged on windows-latest.
2. Invalid strftime format: Toggle %# vs %- format string dynamically to handle platform-specific leading-zero suppression.
3. Path separators: Normalize backslashes to forward slashes in storage_provider.py and server.py directory listing / path parsing.
4. NamedTemporaryFile lock: Closed tempfile xlsx/html file handles before calling excel/shortcut writers, freeing file locks.
Also added unit test coverage in backend/tests/test_windows_compatibility.py.