### PR TITLE
Fix Windows WeasyPrint DLL resolution, implement sidecar self-termination process monitor, and refactor platform compatibility setup

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -50,6 +50,14 @@ jobs:
           uv pip install --system pyinstaller
           uv run python src/mm_to_json/download_libs.py
 
+      - name: Install Pango/Cairo DLLs on Windows
+        if: matrix.platform == 'windows-latest'
+        shell: bash
+        run: |
+          c:/msys64/usr/bin/bash -lc "pacman -Syy --noconfirm --needed mingw-w64-x86_64-pango"
+          mkdir -p backend/src/mm_to_json/lib
+          cp /c/msys64/mingw64/bin/*.dll backend/src/mm_to_json/lib/
+
       - name: Package Python Backend with PyInstaller
         shell: bash
         run: |

--- a/backend/src/handlers/report_handler.py
+++ b/backend/src/handlers/report_handler.py
@@ -62,41 +62,12 @@ def _process_single_report_process(
     import datetime
     import logging
     import os
-    import sys
     import tempfile
     import traceback
 
-    # Apply macOS Homebrew library resolution fallback under SIP
-    if sys.platform == "darwin":
-        homebrew_lib = "/opt/homebrew/lib"
-        if os.path.exists(homebrew_lib):
-            import ctypes.util
+    from mm_to_json.platform_setup import setup_platform_env
 
-            if ctypes.util.find_library.__name__ != "new_find_library":
-                orig_find_library = ctypes.util.find_library
-
-                def new_find_library(name):
-                    res = orig_find_library(name)
-                    if not res:
-                        base_name = name
-                        if name.startswith("lib"):
-                            base_name = name[3:]
-                        if "-" in base_name and not base_name.startswith("harfbuzz-subset"):
-                            base_name = base_name.split("-")[0]
-                        exact_path = os.path.join(homebrew_lib, f"lib{base_name}.dylib")
-                        if os.path.exists(exact_path):
-                            res = exact_path
-                        else:
-                            try:
-                                for f in os.listdir(homebrew_lib):
-                                    if f.startswith(f"lib{base_name}") and f.endswith(".dylib"):
-                                        res = os.path.join(homebrew_lib, f)
-                                        break
-                            except Exception:
-                                pass
-                    return res
-
-                ctypes.util.find_library = new_find_library
+    setup_platform_env()
 
     import msgpack
 

--- a/backend/src/mm_to_json/platform_setup.py
+++ b/backend/src/mm_to_json/platform_setup.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+
+logger = logging.getLogger(__name__)
+
+
+def setup_platform_env():
+    """Initializes platform-specific environment settings (e.g. DLL paths, ctypes patches, process monitors)."""
+    # 1. Platform-Specific Library / DLL Resolution
+    if os.name == "nt":
+        # Windows WeasyPrint DLL Resolution (Cairo / Pango / GObject)
+        lib_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "lib")
+        if os.path.exists(lib_dir):
+            logger.info(f"Windows target detected: adding bundled DLL folder to environment: {lib_dir}")
+            os.environ["WEASYPRINT_DLL_DIRECTORIES"] = lib_dir
+            os.environ["PATH"] = lib_dir + os.pathsep + os.environ.get("PATH", "")
+    elif sys.platform == "darwin":
+        # macOS Homebrew library resolution fallback under SIP
+        homebrew_lib = "/opt/homebrew/lib"
+        if os.path.exists(homebrew_lib):
+            import ctypes.util
+
+            if ctypes.util.find_library.__name__ != "new_find_library":
+                orig_find_library = ctypes.util.find_library
+
+                def new_find_library(name):
+                    res = orig_find_library(name)
+                    if not res:
+                        base_name = name
+                        if name.startswith("lib"):
+                            base_name = name[3:]
+                        if "-" in base_name and not base_name.startswith("harfbuzz-subset"):
+                            base_name = base_name.split("-")[0]
+                        exact_path = os.path.join(homebrew_lib, f"lib{base_name}.dylib")
+                        if os.path.exists(exact_path):
+                            res = exact_path
+                        else:
+                            try:
+                                for f in os.listdir(homebrew_lib):
+                                    if f.startswith(f"lib{base_name}") and f.endswith(".dylib"):
+                                        res = os.path.join(homebrew_lib, f)
+                                        break
+                            except Exception:
+                                pass
+                    return res
+
+                ctypes.util.find_library = new_find_library
+                logger.info("macOS target detected: patched ctypes.util.find_library for Homebrew SIP support.")
+
+    # 2. Orphaning Process Prevention (Self-Termination Monitor)
+    # Start a daemon thread that blocks on sys.stdin.read(1). If the parent
+    # process (Tauri) terminates, the OS closes stdin, read(1) returns EOF,
+    # and this thread terminates the Python sidecar.
+    if os.environ.get("MONITOR_PARENT_PROCESS") != "false":
+        stdin_thread = threading.Thread(target=_monitor_parent_stdin, daemon=True)
+        stdin_thread.start()
+
+
+def _monitor_parent_stdin():
+    logger.debug("Starting parent process stdin monitor thread...")
+    try:
+        sys.stdin.read(1)
+    except Exception as e:
+        logger.debug(f"Parent process stdin monitor read exception: {e}")
+    finally:
+        logger.warning("Parent process stream closed (EOF detected). Terminating sidecar immediately...")
+        # Force immediate exit of the process without throwing exceptions or cleaning up handlers
+        os._exit(0)

--- a/backend/src/mm_to_json/platform_setup.py
+++ b/backend/src/mm_to_json/platform_setup.py
@@ -51,11 +51,7 @@ def setup_platform_env():
                 ctypes.util.find_library = new_find_library
                 logger.info("macOS target detected: patched ctypes.util.find_library for Homebrew SIP support.")
 
-    # 2. Orphaning Process Prevention (Self-Termination Monitor)
-    # Start a daemon thread that blocks on sys.stdin.read(1). If the parent
-    # process (Tauri) terminates, the OS closes stdin, read(1) returns EOF,
-    # and this thread terminates the Python sidecar.
-    if os.environ.get("MONITOR_PARENT_PROCESS") != "false":
+    if os.environ.get("MONITOR_PARENT_PROCESS") == "true":
         stdin_thread = threading.Thread(target=_monitor_parent_stdin, daemon=True)
         stdin_thread.start()
 

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -7,68 +7,35 @@ import logging
 import multiprocessing
 import os
 import signal
-
-# Apply macOS Homebrew library resolution fallback under SIP as early as possible
 import sys
 import tempfile
 import threading
 import time
+import typing
 import uuid
 from collections import OrderedDict
 from concurrent import futures
 from typing import Any
 
-if sys.platform == "darwin":
-    homebrew_lib = "/opt/homebrew/lib"
-    if os.path.exists(homebrew_lib):
-        import ctypes.util
-
-        if ctypes.util.find_library.__name__ != "new_find_library":
-            orig_find_library = ctypes.util.find_library
-
-            def new_find_library(name):
-                res = orig_find_library(name)
-                if not res:
-                    base_name = name
-                    if name.startswith("lib"):
-                        base_name = name[3:]
-                    if "-" in base_name and not base_name.startswith("harfbuzz-subset"):
-                        base_name = base_name.split("-")[0]
-                    exact_path = os.path.join(homebrew_lib, f"lib{base_name}.dylib")
-                    if os.path.exists(exact_path):
-                        res = exact_path
-                    else:
-                        try:
-                            for f in os.listdir(homebrew_lib):
-                                if f.startswith(f"lib{base_name}") and f.endswith(".dylib"):
-                                    res = os.path.join(homebrew_lib, f)
-                                    break
-                        except Exception:
-                            pass
-                return res
-
-            ctypes.util.find_library = new_find_library
-
 import grpc
 from firebase_admin import auth
+from grpc_health.v1 import health, health_pb2, health_pb2_grpc
+
+from meet_validation import validate_meet_data
+from mm_to_json.mm_to_json import MmToJsonConverter
+from mm_to_json.platform_setup import setup_platform_env
+from storage_provider import GCSStorageProvider, LocalStorageProvider, StorageProvider
 
 # Import generated classes
 try:
     from meetmanager.v1 import meet_manager_pb2 as pb2
     from meetmanager.v1 import meet_manager_pb2_grpc as pb2_grpc
 except ImportError:
-    # Fallback for environments where protos aren't generated yet
-    # We use cast to Any to avoid mypy errors when this fallback is active
-    import typing
-
     pb2 = typing.cast(Any, None)
     pb2_grpc = typing.cast(Any, None)
 
-from grpc_health.v1 import health, health_pb2, health_pb2_grpc
-
-from meet_validation import validate_meet_data
-from mm_to_json.mm_to_json import MmToJsonConverter
-from storage_provider import GCSStorageProvider, LocalStorageProvider, StorageProvider
+# Configure platform-specific environments
+setup_platform_env()
 
 # Configure logging
 log_level_str = os.getenv("LOG_LEVEL", "INFO").upper()

--- a/backend/tests/test_windows_compatibility.py
+++ b/backend/tests/test_windows_compatibility.py
@@ -37,3 +37,23 @@ def test_path_normalization_list_datasets():
 
     assert "Singers23.mdb" in parsed_files
     assert "config.json" in parsed_files
+
+
+def test_setup_platform_env_windows():
+    from unittest.mock import patch
+
+    from mm_to_json.platform_setup import setup_platform_env
+
+    # Mock os.name to simulate Windows and os.path.exists to simulate found JRE lib folder
+    # We set MONITOR_PARENT_PROCESS to false to avoid starting parent process monitor thread in test
+    with (
+        patch("os.name", "nt"),
+        patch("os.path.exists", return_value=True),
+        patch.dict("os.environ", {"MONITOR_PARENT_PROCESS": "false"}),
+    ):
+        import os
+
+        setup_platform_env()
+        assert "WEASYPRINT_DLL_DIRECTORIES" in os.environ
+        assert os.environ["WEASYPRINT_DLL_DIRECTORIES"].endswith("lib")
+        assert os.environ["WEASYPRINT_DLL_DIRECTORIES"] in os.environ["PATH"]

--- a/web-client/src-tauri/src/lib.rs
+++ b/web-client/src-tauri/src/lib.rs
@@ -63,13 +63,13 @@ pub fn run() {
                 child: Mutex::new(None),
             });
 
-            // "mmtools-backend" refers to the sidecar defined in tauri.conf.json
             let (mut rx, child) = shell
                 .sidecar("mmtools-backend")
                 .expect("failed to setup sidecar")
                 .env("STORAGE_BASE_DIR", &app_data_str)
                 .env("GRPC_AUTH_DISABLED", "true")
                 .env("DATA_ACCESS_TOKEN", "mmtools-default-secret-2024")
+                .env("MONITOR_PARENT_PROCESS", "true")
                 .spawn()
                 .expect("failed to spawn sidecar");
 


### PR DESCRIPTION
Closes #561. This PR resolves WeasyPrint PDF generation failures and orphan sidecar processes on Windows:
1. **WeasyPrint DLL Resolution**: Installs Cairo/Pango via MSYS2 pacman on the GHA Windows builder and bundles them into the sidecar's lib/ directory, pointing WeasyPrint to them at runtime via `WEASYPRINT_DLL_DIRECTORIES`.
2. **Orphan Sidecar Process Prevention**: Implements a stdin-monitoring daemon thread in a new `platform_setup.py` module, ensuring the sidecar terminates instantly if the parent application crashes or exits.
3. **Refactoring Separation of Concerns**: Consolidates all macOS and Windows-specific ctypes overrides and environment variables in the `platform_setup.py` helper, cleaning up `server.py` and `report_handler.py`.
Unit tests updated and verified locally.