### PR TITLE
Fix GHA Windows matrix platform check and add packaged sidecar validation step

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -51,7 +51,7 @@ jobs:
           uv run python src/mm_to_json/download_libs.py
 
       - name: Install Pango/Cairo DLLs on Windows
-        if: matrix.platform == 'windows-latest'
+        if: matrix.platform == 'windows'
         shell: bash
         run: |
           c:/msys64/usr/bin/bash -lc "pacman -Syy --noconfirm --needed mingw-w64-x86_64-pango"
@@ -62,7 +62,7 @@ jobs:
         shell: bash
         run: |
           cd backend
-          if [ "${{ matrix.platform }}" = "windows-latest" ]; then
+          if [ "${{ matrix.platform }}" = "windows" ]; then
             pyinstaller --onefile --add-data "data/Sample_Data.json;data" --add-data "src/mm_to_json/jre;mm_to_json/jre" --add-data "src/mm_to_json/lib;mm_to_json/lib" --add-data "src/mm_to_json/reporting/templates;mm_to_json/reporting/templates" --name ${{ matrix.output_name }} src/server.py
           else
             pyinstaller --onefile --add-data "data/Sample_Data.json:data" --add-data "src/mm_to_json/jre:mm_to_json/jre" --add-data "src/mm_to_json/lib:mm_to_json/lib" --add-data "src/mm_to_json/reporting/templates:mm_to_json/reporting/templates" --name ${{ matrix.output_name }} src/server.py
@@ -75,6 +75,13 @@ jobs:
           else
             echo "web-client/src-tauri not found. Skipping sidecar binary copy."
           fi
+
+      - name: Validate Packaged Sidecar Binary
+        shell: bash
+        run: |
+          cd backend
+          echo "Testing packaged binary execution..."
+          dist/${{ matrix.output_name }}${{ matrix.sidecar_ext }} --check-weasyprint
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -50,6 +50,11 @@ jobs:
           uv pip install --system pyinstaller
           uv run python src/mm_to_json/download_libs.py
 
+      - name: Install Pango/Cairo on macOS
+        if: matrix.platform == 'macos'
+        run: |
+          brew install pango cairo
+
       - name: Install Pango/Cairo DLLs on Windows
         if: matrix.platform == 'windows'
         shell: bash

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -193,5 +193,12 @@ All agents MUST follow these workflow phases:
 - **Dynamic Port Discovery**: The frontend queries `get_backend_port` via Rust dynamically on every request. Caching this port in JS module scope is strictly forbidden to avoid dynamic startup race conditions.
 - **Filesystem Bypass**: To download report packs/ZIPs in the desktop app, pass the URL to the custom Rust command `copy_file_from_storage(relative_path, dest_path)` which executes direct filesystem copies (`fs::copy`) natively. Large byte arrays must never be serialized as JSON arrays over WebView IPC.
 
+### 21. Windows Dependency Packaging & Sidecar Stdin Monitoring
+- **WeasyPrint Windows DLLs**: WeasyPrint requires Cairo, Pango, and GObject libraries on Windows. In GHA, install `mingw-w64-x86_64-pango` via MSYS2 `pacman` and copy all bin DLLs into `backend/src/mm_to_json/lib/` for PyInstaller packaging. Point WeasyPrint to them at startup using `WEASYPRINT_DLL_DIRECTORIES`.
+- **GHA Matrix Checks**: The GHA workflow matrix uses `platform: windows` (NOT `windows-latest`). Using `windows-latest` in matrix platform checks will cause steps to be silently skipped.
+- **Orphan Sidecar Process Prevention**: The Python sidecar supports stdin parent monitoring to prevent orphan background processes. Ensure `MONITOR_PARENT_PROCESS=true` is set when spawning the sidecar in Tauri, and do not enable it in headless/Docker environments to avoid immediate container exits.
+- **Sidecar Package Validation**: Always run the compiled sidecar with `--check-weasyprint` on both macOS and Windows runners to validate library loading before building installers.
+
+
 
 

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -2341,6 +2341,18 @@ if __name__ == "__main__":
         logging.getLogger("weasyprint").setLevel(logging.WARNING)
         logging.getLogger("jpype").setLevel(logging.WARNING)
 
+    # CLI check for WeasyPrint loading (used by GHA to validate bundling)
+    if len(sys.argv) > 1 and sys.argv[1] == "--check-weasyprint":
+        try:
+            import weasyprint  # noqa: F401
+
+            print("SUCCESS: WeasyPrint imported successfully.")
+            sys.exit(0)
+        except Exception as e:
+            import traceback
+
+            traceback.print_exc()
+            print(f"FAILURE: WeasyPrint import failed: {e}", file=sys.stderr)
+            sys.exit(1)
+
     serve()
-# Triggering fresh CI run with clean lint state
-# Triggering fresh CI run with clean lint state


### PR DESCRIPTION
Closes #563. Corrects `matrix.platform` check to `windows` in `desktop-build.yml` and adds a validation step to run the packaged sidecar with `--check-weasyprint` on the builder runner. This ensures Cairo/Pango DLL loading is automatically validated on future builds.