### PR TITLE
feat: validation check for NS/Scratch status with times in other events

### DIFF
--- a/backend/src/meet_validation.py
+++ b/backend/src/meet_validation.py
@@ -201,12 +201,14 @@ def validate_meet_data(cache: dict[str, Any]) -> list[Any]:
 
     # Pass 1: Build older times map (15-18) for young swimmer fast times comparison
     older_times: dict[tuple[str, int, str], list[float]] = collections.defaultdict(list)
+    athlete_has_valid_time = set()
     for entry in entries:
         ath_id = safe_int(get_field(entry, ["ath_no", "Ath_no"]))
         evt_id = safe_int(get_field(entry, ["event_ptr", "Event_ptr"]) or get_field(entry, ["event_no", "Event_no"]))
         fin_time = safe_float(get_field(entry, ["fin_time", "Fin_time"]))
         fin_stat = safe_str(get_field(entry, ["fin_stat", "Fin_stat"])).upper()
-        if fin_time > 0 and fin_stat not in ["Q", "R"]:
+        if fin_time > 0 and fin_stat not in ["Q", "R", "NS"]:
+            athlete_has_valid_time.add(ath_id)
             ath_info = athletes_map.get(ath_id)
             if ath_info:
                 age = safe_int(ath_info.get("age", 0))
@@ -293,6 +295,24 @@ def validate_meet_data(cache: dict[str, Any]) -> list[Any]:
                         severity=pb2.VALIDATION_SEVERITY_CRITICAL,
                         category="Scratched with Time",
                         message=f"{ath_name} in {evt_desc} (Heat {fin_heat}, Lane {fin_lane}): Scratched but has time {fin_time:.2f}s.",
+                        affected_id=str(ath_id),
+                    )
+                )
+
+        # 11. NS/Scratch with Times (WARNING)
+        if ath_id in athlete_has_valid_time:
+            is_ns = fin_stat == "NS"
+            is_scratch = fin_stat == "R" or scr_stat == 1
+            fin_dq = safe_str(get_field(entry, ["fin_dqcode", "Fin_dqcode"])).strip().upper()
+            is_dfs_dq = fin_stat == "Q" and fin_dq.startswith("7")
+
+            if is_ns or is_scratch or is_dfs_dq:
+                loc = f" (Heat {fin_heat}, Lane {fin_lane})" if fin_heat > 0 and fin_lane > 0 else ""
+                findings.append(
+                    pb2.ValidationFinding(
+                        severity=pb2.VALIDATION_SEVERITY_WARNING,
+                        category="NS/Scratch with Times",
+                        message=f"{ath_name} in {evt_desc}{loc}: Swimmer marked as NS/Scratch/DQ-7 but has valid times in other events.",
                         affected_id=str(ath_id),
                     )
                 )

--- a/backend/tests/test_meet_validation.py
+++ b/backend/tests/test_meet_validation.py
@@ -496,3 +496,47 @@ def test_relays_with_ns_scored_logic():
     assert any("Team Del Prado 'B'" in m for m in messages)
     assert any("Team Del Prado 'C'" in m for m in messages)
     assert not any("Team Del Prado 'A'" in m for m in messages)
+
+
+def test_ns_scratch_with_times():
+    """Verify that swimmers with NS/Scratch/DQ-7 and a valid time in another event are flagged."""
+    cache = {
+        "athlete": [
+            {"ath_no": 1, "first_name": "Alice", "last_name": "Smith", "ath_age": 10, "ath_sex": "F", "team_no": 100},
+            {"ath_no": 2, "first_name": "Bob", "last_name": "Jones", "ath_age": 12, "ath_sex": "M", "team_no": 100},
+        ],
+        "team": [{"team_no": 100, "team_name": "Del Prado", "team_lsc": "DP"}],
+        "event": [
+            {"event_ptr": 10, "event_no": 1, "event_sex": "F", "low_age": 9, "high_age": 10, "ind_rel": "I"},
+            {"event_ptr": 11, "event_no": 2, "event_sex": "F", "low_age": 9, "high_age": 10, "ind_rel": "I"},
+            {"event_ptr": 12, "event_no": 3, "event_sex": "F", "low_age": 9, "high_age": 10, "ind_rel": "I"},
+            {"event_ptr": 13, "event_no": 4, "event_sex": "F", "low_age": 9, "high_age": 10, "ind_rel": "I"},
+        ],
+        "entry": [
+            # Alice: Event 10 has a valid time, Event 11 is NS
+            {"ath_no": 1, "event_ptr": 10, "fin_time": 30.5, "fin_stat": "", "fin_heat": 1, "fin_lane": 3},
+            {"ath_no": 1, "event_ptr": 11, "fin_time": 0.0, "fin_stat": "NS", "fin_heat": 1, "fin_lane": 4},
+            # Bob: Event 12 has a valid time, Event 13 is DQ with code 7P (Declared False Start)
+            {"ath_no": 2, "event_ptr": 12, "fin_time": 28.2, "fin_stat": "", "fin_heat": 1, "fin_lane": 2},
+            {
+                "ath_no": 2,
+                "event_ptr": 13,
+                "fin_time": 0.0,
+                "fin_stat": "Q",
+                "fin_dqcode": "7P",
+                "fin_heat": 1,
+                "fin_lane": 5,
+            },
+        ],
+        "relay": [],
+        "relaynames": [],
+    }
+
+    findings = validate_meet_data(cache)
+    ns_scratch_findings = [f for f in findings if f.category == "NS/Scratch with Times"]
+    assert len(ns_scratch_findings) == 2
+    assert all(f.severity == pb2.VALIDATION_SEVERITY_WARNING for f in ns_scratch_findings)
+
+    messages = [f.message for f in ns_scratch_findings]
+    assert any("Alice Smith" in m and "NS/Scratch/DQ-7" in m for m in messages)
+    assert any("Bob Jones" in m and "NS/Scratch/DQ-7" in m for m in messages)


### PR DESCRIPTION
Implements a validation rule checking for swimmers who have a 'No Show' (NS) status, are scratched (R status / scr_stat), or are disqualified with a 'Scratch/Declared False Start' DQ code (starts with '7'), but still have valid recorded times in other events in the same meet. Closes #566.