### PR TITLE
Use 127.0.0.1 instead of localhost for local endpoints to fix Windows DNS lookup delay and fetch failures

### DIFF
--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -2135,6 +2135,7 @@ def serve_health_check():
                     self.end_headers()
                     self.wfile.write(resp_json.encode("utf-8"))
                 except Exception as e:
+                    logging.exception("Error in REST Gateway do_POST handler")
                     self.send_response(500)
                     self._send_cors_headers()
                     self.end_headers()
@@ -2160,24 +2161,28 @@ def serve_health_check():
 
     in_docker = os.path.exists("/.dockerenv")
     is_local = (os.getenv("GRPC_AUTH_DISABLED") == "true" or not os.getenv("K_SERVICE")) and not in_docker
-    bind_v6 = "::1" if is_local else "::"
+    bind_v6 = "::"
     bind_v4 = "127.0.0.1" if is_local else "0.0.0.0"
 
     rest_port = int(os.getenv("REST_PORT", "8081"))
     httpd: Any = None
     for port_attempt in range(rest_port, rest_port + 10):
         try:
-            # Attempt dual-stack IPv6/IPv4 binding first
-            try:
-                httpd = ThreadingHTTPServerV6((bind_v6, port_attempt), HealthHandler)
-                try:
-                    # Enable dual-stack explicitly (V6ONLY=0)
-                    httpd.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
-                except Exception:
-                    pass
-            except Exception:
-                # Fallback to IPv4
+            if is_local:
+                # Local dev/desktop: bind strictly to IPv4 127.0.0.1 to avoid Windows localhost loopback mismatch
                 httpd = ThreadingHTTPServerV4((bind_v4, port_attempt), HealthHandler)
+            else:
+                # Staging/Production: attempt dual-stack IPv6/IPv4 binding
+                try:
+                    httpd = ThreadingHTTPServerV6((bind_v6, port_attempt), HealthHandler)
+                    try:
+                        # Enable dual-stack explicitly (V6ONLY=0)
+                        httpd.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+                    except Exception:
+                        pass
+                except Exception:
+                    # Fallback to IPv4
+                    httpd = ThreadingHTTPServerV4((bind_v4, port_attempt), HealthHandler)
             rest_port = port_attempt
             global ACTUAL_REST_PORT
             ACTUAL_REST_PORT = rest_port

--- a/web-client/app/actions.client.ts
+++ b/web-client/app/actions.client.ts
@@ -680,7 +680,7 @@ export async function getDashboardStats() {
 
 export async function publishMeetData(_filename: string, _baseUrl: string) {
 	const restPort = await getRestPort();
-	const localUrl = `http://localhost:${restPort}`;
+	const localUrl = `http://127.0.0.1:${restPort}`;
 	const response = await callRestGateway("PublishMeetData", {
 		frontendUrl: localUrl,
 	});
@@ -897,7 +897,7 @@ export async function resolveBundleUrl(bundleUrl: string): Promise<string> {
 	if (!bundleUrl) return "";
 	const restPort = await getRestPort();
 	if (bundleUrl.startsWith("/")) {
-		return `http://localhost:${restPort}${bundleUrl}`;
+		return `http://127.0.0.1:${restPort}${bundleUrl}`;
 	}
 	try {
 		const url = new URL(bundleUrl);
@@ -907,7 +907,7 @@ export async function resolveBundleUrl(bundleUrl: string): Promise<string> {
 			url.protocol === "tauri:"
 		) {
 			url.protocol = "http:";
-			url.host = `localhost:${restPort}`;
+			url.host = `127.0.0.1:${restPort}`;
 			return url.toString();
 		}
 	} catch (_e) {}

--- a/web-client/lib/mm-client.ts
+++ b/web-client/lib/mm-client.ts
@@ -26,7 +26,7 @@ if (typeof window === "undefined") {
 			if (fs.existsSync(registryPath)) {
 				const data = JSON.parse(fs.readFileSync(registryPath, "utf-8"));
 				if (data?.grpc_port) {
-					resolvedHost = `localhost:${data.grpc_port}`;
+					resolvedHost = `127.0.0.1:${data.grpc_port}`;
 					console.log(
 						`[mm-client] Resolved backend gRPC host from active_ports.json: ${resolvedHost}`,
 					);
@@ -43,7 +43,7 @@ if (typeof window === "undefined") {
 	defaultHost = resolvedHost || "backend:8080";
 } else {
 	const port = process.env.NEXT_PUBLIC_BACKEND_PORT || "8081";
-	defaultHost = `localhost:${port}`;
+	defaultHost = `127.0.0.1:${port}`;
 }
 
 const authMiddleware = async function* (call: any, options: any) {
@@ -184,7 +184,7 @@ async function getOrInitClient(): Promise<MeetManagerServiceClient> {
 				const ports = await invoke<[number, number]>("get_backend_ports");
 				if (ports?.[0]) {
 					const dynamicPort = ports[0];
-					targetHost = `localhost:${dynamicPort}`;
+					targetHost = `127.0.0.1:${dynamicPort}`;
 					console.log(
 						`Tauri dynamic discovery: resolved backend port to ${dynamicPort}`,
 					);

--- a/web-client/lib/tauri-bridge.ts
+++ b/web-client/lib/tauri-bridge.ts
@@ -53,7 +53,7 @@ export async function callRestGateway(method: string, payload: any) {
 			}
 
 			const response = await fetch(
-				`http://localhost:${restPort}/api/grpc/${method}`,
+				`http://127.0.0.1:${restPort}/api/grpc/${method}`,
 				{
 					method: "POST",
 					headers: {

--- a/web-client/tests-e2e/dq_notes.spec.ts
+++ b/web-client/tests-e2e/dq_notes.spec.ts
@@ -32,7 +32,7 @@ test.describe("DQ Notes Preservation", () => {
 			process.env.DATA_ACCESS_TOKEN || "mmtools-default-secret-2024";
 		const syncBase =
 			process.env.TEST_STATIC === "true"
-				? `http://localhost:${getDynamicGatewayPort()}`
+				? `http://127.0.0.1:${getDynamicGatewayPort()}`
 				: baseURL;
 
 		const testFileName = getFilename("tiny_meet.json");

--- a/web-client/tests-e2e/utils.ts
+++ b/web-client/tests-e2e/utils.ts
@@ -171,7 +171,7 @@ export function getDynamicGatewayPort(): number {
 }
 
 export function getDynamicGatewayUrl(): string {
-	return `http://localhost:${getDynamicGatewayPort()}/api/grpc`;
+	return `http://127.0.0.1:${getDynamicGatewayPort()}/api/grpc`;
 }
 
 /**


### PR DESCRIPTION
Binds local HTTP health/REST server strictly to 127.0.0.1 and updates Next.js and Tauri client fetch / gRPC targets to connect via 127.0.0.1. This resolves loopback DNS resolution delays and connection errors on Windows.