### PR TITLE
Optimize Tauri App Startup Performance (JRE Bundling & Sidecar Pre-warming)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -68,15 +68,17 @@ jobs:
         run: |
           cd backend
           if [ "${{ matrix.platform }}" = "windows" ]; then
-            pyinstaller --onefile --add-data "data/Sample_Data.json;data" --add-data "src/mm_to_json/jre;mm_to_json/jre" --add-data "src/mm_to_json/lib;mm_to_json/lib" --add-data "src/mm_to_json/reporting/templates;mm_to_json/reporting/templates" --name ${{ matrix.output_name }} src/server.py
+            pyinstaller --onefile --add-data "data/Sample_Data.json;data" --add-data "src/mm_to_json/lib;mm_to_json/lib" --add-data "src/mm_to_json/reporting/templates;mm_to_json/reporting/templates" --name ${{ matrix.output_name }} src/server.py
           else
-            pyinstaller --onefile --add-data "data/Sample_Data.json:data" --add-data "src/mm_to_json/jre:mm_to_json/jre" --add-data "src/mm_to_json/lib:mm_to_json/lib" --add-data "src/mm_to_json/reporting/templates:mm_to_json/reporting/templates" --name ${{ matrix.output_name }} src/server.py
+            pyinstaller --onefile --add-data "data/Sample_Data.json:data" --add-data "src/mm_to_json/lib:mm_to_json/lib" --add-data "src/mm_to_json/reporting/templates:mm_to_json/reporting/templates" --name ${{ matrix.output_name }} src/server.py
           fi
           
           # Move output to Tauri's sidecars directory in web-client if it exists
           if [ -d "../web-client/src-tauri" ]; then
             mkdir -p ../web-client/src-tauri/binaries
             cp dist/${{ matrix.output_name }}${{ matrix.sidecar_ext }} ../web-client/src-tauri/binaries/
+            # Copy JRE as a resource to binaries/jre so Tauri packages it
+            cp -r src/mm_to_json/jre ../web-client/src-tauri/binaries/
           else
             echo "web-client/src-tauri not found. Skipping sidecar binary copy."
           fi

--- a/backend/src/mm_to_json/mdb_writer.py
+++ b/backend/src/mm_to_json/mdb_writer.py
@@ -46,9 +46,39 @@ def ensure_jvm_started():
     # Discover JVM path
     jvm_path = None
 
-    # 1. Try local JRE first to avoid system warnings on macOS
-    base_dir = os.path.dirname(os.path.abspath(__file__))
-    local_jre = os.path.join(base_dir, "jre")
+    # 1. Try resolving via environment variable from Tauri first
+    import sys
+
+    local_jre = None
+    tauri_resource_dir = os.getenv("TAURI_RESOURCE_DIR")
+    if tauri_resource_dir:
+        tauri_jre_binaries = os.path.join(tauri_resource_dir, "binaries", "jre")
+        if os.path.exists(tauri_jre_binaries):
+            local_jre = tauri_jre_binaries
+            logger.debug(f"Found JRE via TAURI_RESOURCE_DIR binaries: {local_jre}")
+        else:
+            tauri_jre = os.path.join(tauri_resource_dir, "jre")
+            if os.path.exists(tauri_jre):
+                local_jre = tauri_jre
+                logger.debug(f"Found JRE via TAURI_RESOURCE_DIR direct: {local_jre}")
+
+    # 2. Fallback to frozen executable location path discovery
+    if not local_jre and getattr(sys, "frozen", False):
+        exe_dir = os.path.dirname(sys.executable)
+        tauri_jre_binaries = os.path.join(exe_dir, "binaries", "jre")
+        if os.path.exists(tauri_jre_binaries):
+            local_jre = tauri_jre_binaries
+            logger.debug(f"Found JRE in Tauri binaries resources: {local_jre}")
+        else:
+            tauri_jre = os.path.join(exe_dir, "jre")
+            if os.path.exists(tauri_jre):
+                local_jre = tauri_jre
+                logger.debug(f"Found JRE in Tauri resources: {local_jre}")
+
+    if not local_jre:
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        local_jre = os.path.join(base_dir, "jre")
+
     if os.path.exists(local_jre):
         import platform
 

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -960,14 +960,7 @@ class MeetManagerService(pb2_grpc.MeetManagerServiceServicer):
             if hasattr(self.storage, "_get_full_path"):
                 logging.info("ListDatasets: Checking local path")
 
-            # Retry loop for eventual consistency in CI environments            files = []
-            for attempt in range(5):
-                files = self.storage.list_files(user_prefix)
-                if files:
-                    break
-                if attempt < 4:
-                    logging.info(f"ListDatasets: No files found for {self._mask_uid(uid)}, retrying in 2s...")
-                    time.sleep(2)
+            files = self.storage.list_files(user_prefix)
 
             logging.info(f"ListDatasets: Found {len(files)} files in {self._mask_path(user_prefix)}: {files}")
 

--- a/web-client/src-tauri/src/lib.rs
+++ b/web-client/src-tauri/src/lib.rs
@@ -64,6 +64,12 @@ pub fn run() {
                 child: Mutex::new(None),
             });
 
+            let resource_dir = app
+                .path()
+                .resource_dir()
+                .expect("failed to get resource dir");
+            let resource_dir_str = resource_dir.to_string_lossy().to_string();
+
             let (mut rx, child) = shell
                 .sidecar("mmtools-backend")
                 .expect("failed to setup sidecar")
@@ -71,6 +77,7 @@ pub fn run() {
                 .env("GRPC_AUTH_DISABLED", "true")
                 .env("DATA_ACCESS_TOKEN", "mmtools-default-secret-2024")
                 .env("MONITOR_PARENT_PROCESS", "true")
+                .env("TAURI_RESOURCE_DIR", &resource_dir_str)
                 .spawn()
                 .expect("failed to spawn sidecar");
 
@@ -129,6 +136,35 @@ pub fn run() {
                     }
                 }
             });
+
+            // Wait for backend REST server to start and port to become connectable
+            log::info!("Waiting for backend REST server to start...");
+            let mut ready = false;
+            let start_time = std::time::Instant::now();
+            let timeout = std::time::Duration::from_secs(15);
+            
+            while start_time.elapsed() < timeout {
+                let current_port = {
+                    let state = app.state::<BackendState>();
+                    let port_guard = state.port.lock().unwrap();
+                    port_guard.clone()
+                };
+                
+                if current_port != "8081" || start_time.elapsed() > std::time::Duration::from_millis(500) {
+                    let addr = format!("127.0.0.1:{}", current_port);
+                    if let Ok(_stream) = std::net::TcpStream::connect(&addr) {
+                        log::info!("Successfully connected to backend REST server at {}", addr);
+                        ready = true;
+                        break;
+                    }
+                }
+                
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            
+            if !ready {
+                log::error!("Backend REST server failed to start within timeout.");
+            }
 
             Ok(())
         })

--- a/web-client/src-tauri/tauri.conf.json
+++ b/web-client/src-tauri/tauri.conf.json
@@ -35,6 +35,7 @@
 			"icons/icon.ico"
 		],
 		"externalBin": ["binaries/mmtools-backend"],
+		"resources": ["binaries/jre"],
 		"android": {
 			"debugApplicationIdSuffix": ".debug"
 		}


### PR DESCRIPTION
Resolves issue #572. Moves the 151MB JRE folder from PyInstaller single-file backend binary to Tauri bundle resources, reducing PyInstaller binary size and cold decompression overhead. Implements standard TCP stream connect polling inside Tauri Rust setup hook to block window rendering until the backend is fully connectable. Fixes ListDatasets unconditional 8s retry loop for new users.