### PR TITLE
Fix: resolve report bundle generation hangs on Tauri desktop app

### DIFF
--- a/backend/src/handlers/report_handler.py
+++ b/backend/src/handlers/report_handler.py
@@ -486,6 +486,8 @@ def _run_bundle_generation_job(
 
         servicer.job_manager.update_job(job_id, progress=0.05, message=f"Rendering {len(request.reports)} reports...")
         is_frozen = getattr(sys, "frozen", False)
+        executor_class: Any
+        executor_kwargs: dict[str, Any]
         if is_frozen:
             from concurrent.futures import ThreadPoolExecutor
 

--- a/backend/src/handlers/report_handler.py
+++ b/backend/src/handlers/report_handler.py
@@ -485,14 +485,26 @@ def _run_bundle_generation_job(
             max_workers = min(os.cpu_count() or 4, 8)
 
         servicer.job_manager.update_job(job_id, progress=0.05, message=f"Rendering {len(request.reports)} reports...")
-        logging.info(f"Job {job_id}: starting ProcessPoolExecutor with {max_workers} workers")
+        is_frozen = getattr(sys, "frozen", False)
+        if is_frozen:
+            from concurrent.futures import ThreadPoolExecutor
 
-        ctx = multiprocessing.get_context("spawn")
+            logging.info(
+                f"Job {job_id}: running in frozen environment. Using ThreadPoolExecutor with {max_workers} workers."
+            )
+            executor_class = ThreadPoolExecutor
+            executor_kwargs = {"max_workers": max_workers}
+        else:
+            logging.info(f"Job {job_id}: starting ProcessPoolExecutor with {max_workers} workers")
+            executor_class = ProcessPoolExecutor
+            ctx = multiprocessing.get_context("spawn")
+            executor_kwargs = {"max_workers": max_workers, "mp_context": ctx}
+
         try:
             report_reqs = list(request.reports)
             user_email = get_user_email(uid)
 
-            with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as executor:
+            with executor_class(**executor_kwargs) as executor:
                 for idx, report_req in enumerate(report_reqs):
                     tasks.append(
                         executor.submit(

--- a/web-client/tests-e2e/tauri_smoke.spec.ts
+++ b/web-client/tests-e2e/tauri_smoke.spec.ts
@@ -134,6 +134,47 @@ test("Tauri Desktop App functional navigation & data query check", async ({
 		timeout: 60000,
 	});
 
+	// 6. Navigation to Reports & PDF generation (Single PDF)
+	console.log(
+		"E2E TEST: Navigating to Reports and generating single report...",
+	);
+	await page.click("text=Reports");
+	await expect(
+		page.locator("text=Select a report type to configure and generate"),
+	).toBeVisible({
+		timeout: 15000,
+	});
+
+	const generateBtn = page.getByTestId("generate-report-button");
+	await expect(generateBtn).toBeVisible({ timeout: 10000 });
+	await generateBtn.click();
+
+	// Wait for the success toast message
+	await expect(page.locator("text=Report generated successfully")).toBeVisible({
+		timeout: 45000,
+	});
+	console.log("E2E TEST: Single PDF report generated successfully.");
+
+	// 7. Add to Pack and generate ZIP bundle
+	console.log("E2E TEST: Adding report to pack and generating ZIP bundle...");
+	await page.getByRole("button", { name: /Add to Pack/i }).click();
+
+	const builderCard = page.getByTestId("report-builder-card");
+	const generateBundleBtn = builderCard.getByTestId("generate-bundle-button");
+	await expect(generateBundleBtn).toBeVisible({ timeout: 10000 });
+	await generateBundleBtn.click();
+
+	// Assert the status transitions to bundling
+	await expect(builderCard).toHaveAttribute("data-report-status", "bundling", {
+		timeout: 15000,
+	});
+
+	// Wait for the bundle generation to complete and return to idle status
+	await expect(builderCard).toHaveAttribute("data-report-status", "idle", {
+		timeout: 60000,
+	});
+	console.log("E2E TEST: ZIP bundle generated successfully.");
+
 	// Cleanly close the browser context to finalize trace/screenshot capture
 	await browser.close();
 });

--- a/web-client/tests-e2e/tauri_smoke.spec.ts
+++ b/web-client/tests-e2e/tauri_smoke.spec.ts
@@ -135,15 +135,17 @@ test("Tauri Desktop App functional navigation & data query check", async ({
 	});
 
 	// 6. Navigation to Reports & PDF generation (Single PDF)
-	console.log(
-		"E2E TEST: Navigating to Reports and generating single report...",
-	);
+	console.log("E2E TEST: Navigating to Reports and generating single report...");
 	await page.click("text=Reports");
 	await expect(
 		page.locator("text=Select a report type to configure and generate"),
 	).toBeVisible({
 		timeout: 15000,
 	});
+
+	// Select the Psych Sheet report card to show the configuration options
+	const psychCard = page.getByTestId("report-card-psych-sheet");
+	await psychCard.click();
 
 	const generateBtn = page.getByTestId("generate-report-button");
 	await expect(generateBtn).toBeVisible({ timeout: 10000 });

--- a/web-client/tests-e2e/tauri_smoke.spec.ts
+++ b/web-client/tests-e2e/tauri_smoke.spec.ts
@@ -135,7 +135,9 @@ test("Tauri Desktop App functional navigation & data query check", async ({
 	});
 
 	// 6. Navigation to Reports & PDF generation (Single PDF)
-	console.log("E2E TEST: Navigating to Reports and generating single report...");
+	console.log(
+		"E2E TEST: Navigating to Reports and generating single report...",
+	);
 	await page.click("text=Reports");
 	await expect(
 		page.locator("text=Select a report type to configure and generate"),


### PR DESCRIPTION
This PR switches report generation from ProcessPoolExecutor to ThreadPoolExecutor when running in a frozen/compiled PyInstaller environment (such as the Tauri desktop client sidecar). This avoids OS-level process spawning permission issues and JNI/JVM collision deadlocks in sandboxed/packaged desktop environments, resolving the report pack hang in the Mac/Windows desktop applications. It also updates the Tauri smoke E2E tests to explicitly verify PDF and ZIP report bundle generation.