### PR TITLE
fix(reporting): restore nested athlete loop to fix blank parent entries report

### DIFF
--- a/backend/src/mm_to_json/reporting/templates/entries_hytek.j2
+++ b/backend/src/mm_to_json/reporting/templates/entries_hytek.j2
@@ -38,18 +38,20 @@
 
 {% block content %}
     {% for group in groups %}
-    <div class="athlete-block">
-        <div class="athlete-header">
-            {{ group.header }}
-        </div>
-        <div class="events-grid">
-            {% for event in group.sub_items %}
-            <div class="event-entry">
-                <span class="event-num-name">#{{ event.event_num }} {{ event.event_name }}</span>
-                <span class="event-time">{{ event.time }}</span>
+        {% for athlete in group.sub_items %}
+        <div class="athlete-block">
+            <div class="athlete-header">
+                {{ athlete.header }}
             </div>
-            {% endfor %}
+            <div class="events-grid">
+                {% for event in athlete.sub_items %}
+                <div class="event-entry">
+                    <span class="event-num-name">#{{ event.event_num }} {{ event.event_name }}</span>
+                    <span class="event-time">{{ event.time }}</span>
+                </div>
+                {% endfor %}
+            </div>
         </div>
-    </div>
+        {% endfor %}
     {% endfor %}
 {% endblock %}


### PR DESCRIPTION
This PR fixes the entries_hytek template formatting bug by restoring the nested athlete loop over group.sub_items.