### PR TITLE
feat: show team abbreviation for swimmers and warn for single event entries in champs

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -174,6 +174,13 @@ All agents MUST follow these workflow phases:
   - **Tied-Rank Verification Safeguards**: To avoid false-positives when a swimmer has multiple equal-ranked top events (e.g., four tied 1st place events but only 3 entries), missed events are only flagged if their rank is strictly better than the worst entered individual event.
   - **PDF Layout**: Highlight the worst-ranked entered stroke in yellow as the primary candidate to drop/replace. Repeats table headers on page wraps (`repeatRows=1` in ReportLab) and adds a generation timestamp and legend.
 
+- **2026-07-18**: **TVSL Championships Results Celebration Report**:
+  - **Goal**: Generate a parent/swimmer-facing results celebration report from the final TVSL Championships MDB results database.
+  - **Time-Drop Tiers**: Grouped time drops into motivating categories: "The Fingertip Finish" (<0.5s), "The Streamline Surge" (0.5s-1.99s), "The Sonic Surge" (2.0s-4.99s), and "The Tidal Wave" (5.0s+).
+  - **Celebration Highlights**: Included relay collective drops, a "Clean Sweep Club" of swimmers with 100% PBs, and total team time-saved metrics.
+  - **Design & Layout**: Customized WeasyPrint PDF layout using a Forest Green and Champagne Gold color system, Georgia/Helvetica font pairing, and `display: table` print standard.
+
+
 ### 11. Season Setup Automation
 - **Rule**: Use the `season-setup` skill when configuring MDB files for a new swim season.
 - **Architecture**:

--- a/backend/src/meet_validation.py
+++ b/backend/src/meet_validation.py
@@ -127,15 +127,26 @@ def validate_meet_data(cache: dict[str, Any]) -> list[Any]:
     entries = get_table(cache, "entry")
     relays = get_table(cache, "relay")
     relay_names = get_table(cache, "relaynames")
+    meet_table = get_table(cache, "meet")
+
+    # Detect if this is a Championship/Champs meet
+    is_champs = False
+    if meet_table:
+        meet_info = meet_table[0] if len(meet_table) > 0 else {}
+        meet_name = str(get_field(meet_info, ["meet_name1", "Meet_name1"]) or "").lower()
+        if "championship" in meet_name or "champs" in meet_name:
+            is_champs = True
 
     # Build lookups
     teams_map = {}
     for t in teams:
         t_no = safe_int(get_field(t, ["team_no", "Team_no"]))
         t_name = get_field(t, ["team_name", "Team_name"])
+        t_abbr = get_field(t, ["team_abbr", "Team_abbr"])
         t_lsc = get_field(t, ["team_lsc", "Team_lsc"])
         if t_no:
-            teams_map[t_no] = {"name": t_name, "lsc": t_lsc}
+            abbr_str = str(t_abbr or "").strip()
+            teams_map[t_no] = {"name": t_name, "abbr": abbr_str, "lsc": t_lsc}
             # WARNING: Check for missing LSC code
             if not t_lsc or not str(t_lsc).strip():
                 findings.append(
@@ -267,7 +278,7 @@ def validate_meet_data(cache: dict[str, Any]) -> list[Any]:
         ath = athletes_map.get(ath_id, {})
         t_no = safe_int(ath.get("team_no", 0))
         t_info = teams_map.get(t_no, {})
-        t_code = t_info.get("lsc", "")
+        t_code = t_info.get("abbr", "") or t_info.get("lsc", "")
         ath_name = str(ath.get("name", f"Swimmer #{ath_id}"))
         if t_code:
             ath_name = f"{ath_name} [{t_code}]"
@@ -459,7 +470,7 @@ def validate_meet_data(cache: dict[str, Any]) -> list[Any]:
         ath_info = athletes_map.get(ath_id, {})
         t_no = safe_int(ath_info.get("team_no", 0))
         t_info = teams_map.get(t_no, {})
-        t_code = t_info.get("lsc", "")
+        t_code = t_info.get("abbr", "") or t_info.get("lsc", "")
         name = str(ath_info.get("name", f"Swimmer #{ath_id}"))
         if t_code:
             name = f"{name} [{t_code}]"
@@ -583,6 +594,24 @@ def validate_meet_data(cache: dict[str, Any]) -> list[Any]:
                     severity=pb2.VALIDATION_SEVERITY_WARNING,
                     category="Rules Limit",
                     message=f"Swimmer {name} exceeds total entry limits with {ind_count + rel_count} total entries (max: 4).",
+                    affected_id=str(ath_id),
+                )
+            )
+
+        # WARNING: Swimmers with only 1 entry in Championship meets
+        if is_champs and (ind_count + rel_count) == 1:
+            single_event_desc = "Unknown"
+            for item in ath_evts:
+                if not item.get("is_scratched", False) and not item["is_exhibition"]:
+                    evt_info = events_map.get(item["evt_id"])
+                    if evt_info:
+                        single_event_desc = evt_info.get("desc", f"Event {item['evt_id']}")
+                        break
+            findings.append(
+                pb2.ValidationFinding(
+                    severity=pb2.VALIDATION_SEVERITY_WARNING,
+                    category="Champs Single Entry",
+                    message=f"Swimmer {name} is entered in only 1 event ({single_event_desc}) in Championship meet.",
                     affected_id=str(ath_id),
                 )
             )

--- a/backend/tests/test_meet_validation.py
+++ b/backend/tests/test_meet_validation.py
@@ -779,21 +779,15 @@ def test_tvsl_swim_up_rules():
 
 
 def test_swimmer_team_code():
-    """Verify that swimmer team code (LSC) is appended to swimmer's name in warnings/errors."""
-    cache = {
+    """Verify that swimmer team code (abbr preferred, lsc fallback) is appended to swimmer's name in warnings/errors."""
+    # Test fallback to team_lsc
+    cache_lsc = {
         "athlete": [
             {"ath_no": 1, "first_name": "Alice", "last_name": "Smith", "ath_age": 10, "ath_sex": "F", "team_no": 100},
         ],
         "team": [{"team_no": 100, "team_name": "Del Prado", "team_lsc": "DP"}],
         "event": [
-            {
-                "event_ptr": 1,
-                "event_no": 1,
-                "event_sex": "M",
-                "low_age": 9,
-                "high_age": 10,
-                "ind_rel": "I",
-            },  # Gender mismatch
+            {"event_ptr": 1, "event_no": 1, "event_sex": "M", "low_age": 9, "high_age": 10, "ind_rel": "I"}, # Gender mismatch
         ],
         "entry": [
             {"ath_no": 1, "event_ptr": 1, "fin_time": 0.0, "fin_stat": "", "scr_stat": 0},
@@ -802,6 +796,58 @@ def test_swimmer_team_code():
         "relaynames": [],
     }
 
+    findings_lsc = validate_meet_data(cache_lsc)
+    assert len(findings_lsc) > 0
+    assert "Alice Smith [DP]" in findings_lsc[0].message
+
+    # Test preference for team_abbr
+    cache_abbr = {
+        "athlete": [
+            {"ath_no": 1, "first_name": "Alice", "last_name": "Smith", "ath_age": 10, "ath_sex": "F", "team_no": 100},
+        ],
+        "team": [{"team_no": 100, "team_name": "Del Prado", "team_abbr": "DP_ABBR", "team_lsc": "TV"}],
+        "event": [
+            {"event_ptr": 1, "event_no": 1, "event_sex": "M", "low_age": 9, "high_age": 10, "ind_rel": "I"}, # Gender mismatch
+        ],
+        "entry": [
+            {"ath_no": 1, "event_ptr": 1, "fin_time": 0.0, "fin_stat": "", "scr_stat": 0},
+        ],
+        "relay": [],
+        "relaynames": [],
+    }
+
+    findings_abbr = validate_meet_data(cache_abbr)
+    assert len(findings_abbr) > 0
+    assert "Alice Smith [DP_ABBR]" in findings_abbr[0].message
+
+
+def test_champs_single_entry():
+    """Verify that swimmers with only 1 active entry in a Championship meet are flagged."""
+    cache = {
+        "meet": [{"meet_name1": "TVSL Championship Meet 2026"}],
+        "athlete": [
+            {"ath_no": 1, "first_name": "Alice", "last_name": "Smith", "ath_age": 10, "ath_sex": "F", "team_no": 100},
+            {"ath_no": 2, "first_name": "Bob", "last_name": "Jones", "ath_age": 10, "ath_sex": "M", "team_no": 100},
+        ],
+        "team": [{"team_no": 100, "team_name": "Del Prado", "team_abbr": "DP"}],
+        "event": [
+            {"event_ptr": 1, "event_no": 1, "event_sex": "F", "low_age": 9, "high_age": 10, "ind_rel": "I", "desc": "Girls 9-10 25 Free"},
+            {"event_ptr": 2, "event_no": 2, "event_sex": "F", "low_age": 9, "high_age": 10, "ind_rel": "I", "desc": "Girls 9-10 25 Back"},
+        ],
+        "entry": [
+            # Alice only has 1 active entry
+            {"ath_no": 1, "event_ptr": 1, "fin_time": 0.0, "fin_stat": "", "scr_stat": 0},
+            # Bob has 2 entries
+            {"ath_no": 2, "event_ptr": 1, "fin_time": 0.0, "fin_stat": "", "scr_stat": 0},
+            {"ath_no": 2, "event_ptr": 2, "fin_time": 0.0, "fin_stat": "", "scr_stat": 0},
+        ],
+        "relay": [],
+        "relaynames": [],
+    }
+
     findings = validate_meet_data(cache)
-    assert len(findings) > 0
-    assert "Alice Smith [DP]" in findings[0].message
+    champs_findings = [f for f in findings if f.category == "Champs Single Entry"]
+    
+    assert len(champs_findings) == 1
+    assert "Alice Smith [DP]" in champs_findings[0].message
+    assert "Event 1" in champs_findings[0].message

--- a/backend/tests/test_meet_validation.py
+++ b/backend/tests/test_meet_validation.py
@@ -787,7 +787,14 @@ def test_swimmer_team_code():
         ],
         "team": [{"team_no": 100, "team_name": "Del Prado", "team_lsc": "DP"}],
         "event": [
-            {"event_ptr": 1, "event_no": 1, "event_sex": "M", "low_age": 9, "high_age": 10, "ind_rel": "I"}, # Gender mismatch
+            {
+                "event_ptr": 1,
+                "event_no": 1,
+                "event_sex": "M",
+                "low_age": 9,
+                "high_age": 10,
+                "ind_rel": "I",
+            },  # Gender mismatch
         ],
         "entry": [
             {"ath_no": 1, "event_ptr": 1, "fin_time": 0.0, "fin_stat": "", "scr_stat": 0},
@@ -807,7 +814,14 @@ def test_swimmer_team_code():
         ],
         "team": [{"team_no": 100, "team_name": "Del Prado", "team_abbr": "DP_ABBR", "team_lsc": "TV"}],
         "event": [
-            {"event_ptr": 1, "event_no": 1, "event_sex": "M", "low_age": 9, "high_age": 10, "ind_rel": "I"}, # Gender mismatch
+            {
+                "event_ptr": 1,
+                "event_no": 1,
+                "event_sex": "M",
+                "low_age": 9,
+                "high_age": 10,
+                "ind_rel": "I",
+            },  # Gender mismatch
         ],
         "entry": [
             {"ath_no": 1, "event_ptr": 1, "fin_time": 0.0, "fin_stat": "", "scr_stat": 0},
@@ -831,8 +845,24 @@ def test_champs_single_entry():
         ],
         "team": [{"team_no": 100, "team_name": "Del Prado", "team_abbr": "DP"}],
         "event": [
-            {"event_ptr": 1, "event_no": 1, "event_sex": "F", "low_age": 9, "high_age": 10, "ind_rel": "I", "desc": "Girls 9-10 25 Free"},
-            {"event_ptr": 2, "event_no": 2, "event_sex": "F", "low_age": 9, "high_age": 10, "ind_rel": "I", "desc": "Girls 9-10 25 Back"},
+            {
+                "event_ptr": 1,
+                "event_no": 1,
+                "event_sex": "F",
+                "low_age": 9,
+                "high_age": 10,
+                "ind_rel": "I",
+                "desc": "Girls 9-10 25 Free",
+            },
+            {
+                "event_ptr": 2,
+                "event_no": 2,
+                "event_sex": "F",
+                "low_age": 9,
+                "high_age": 10,
+                "ind_rel": "I",
+                "desc": "Girls 9-10 25 Back",
+            },
         ],
         "entry": [
             # Alice only has 1 active entry
@@ -847,7 +877,7 @@ def test_champs_single_entry():
 
     findings = validate_meet_data(cache)
     champs_findings = [f for f in findings if f.category == "Champs Single Entry"]
-    
+
     assert len(champs_findings) == 1
     assert "Alice Smith [DP]" in champs_findings[0].message
     assert "Event 1" in champs_findings[0].message


### PR DESCRIPTION
Prefers team abbreviation short code over LSC in findings messages, and warns when a swimmer only has 1 active entry in a Championship meet.