### PR TITLE
fix: check pre_stat scratches when calculating team splashes limit

### DIFF
--- a/backend/src/meet_validation.py
+++ b/backend/src/meet_validation.py
@@ -622,11 +622,12 @@ def validate_meet_data(cache: dict[str, Any]) -> list[Any]:
     # Count individual swims (excluding scratches)
     for entry in entries:
         ath_id = safe_int(get_field(entry, ["ath_no", "Ath_no"]))
-        fin_stat = safe_str(get_field(entry, ["fin_stat", "Fin_stat"])).upper()
+        fin_stat = safe_str(get_field(entry, ["fin_stat", "Fin_stat"])).strip().upper()
+        pre_stat = safe_str(get_field(entry, ["pre_stat", "Pre_stat"])).strip().upper()
         scr_stat = safe_int(get_field(entry, ["scr_stat", "Scr_stat"]))
 
         # Exclude scratches and no shows
-        if fin_stat == "R" or fin_stat == "NS" or scr_stat == 1:
+        if fin_stat in ["R", "NS"] or pre_stat in ["R", "NS"] or scr_stat == 1:
             continue
 
         ath_info = athletes_map.get(ath_id)
@@ -638,10 +639,11 @@ def validate_meet_data(cache: dict[str, Any]) -> list[Any]:
     # Count relay team entries (excluding scratches)
     for r in relays:
         t_no = safe_int(get_field(r, ["team_ptr", "team_no", "Team_ptr", "Team_no"]))
-        fin_stat = safe_str(get_field(r, ["fin_stat", "Fin_stat"])).upper()
+        fin_stat = safe_str(get_field(r, ["fin_stat", "Fin_stat"])).strip().upper()
+        pre_stat = safe_str(get_field(r, ["pre_stat", "Pre_stat"])).strip().upper()
 
         # Exclude scratches and no shows
-        if fin_stat == "R" or fin_stat == "NS":
+        if fin_stat in ["R", "NS"] or pre_stat in ["R", "NS"]:
             continue
 
         if t_no:

--- a/backend/tests/test_meet_validation.py
+++ b/backend/tests/test_meet_validation.py
@@ -587,8 +587,10 @@ def test_team_splashes_limit():
     assert "exceeds splashes limit" in splashes_findings[0].message
     assert "421" in splashes_findings[0].message
 
-    # Scratches excluded: 401 entries total but 2 individual scratched, 1 relay scratched
-    # 401 individual (2 scratched) + 5 relays (1 scratched) = 399 + 4 * 4 = 415 splashes (under limit)
+    # Scratches excluded: 401 entries total but 3 individual scratched, 2 relays scratched
+    # 401 individual (3 scratched: 1 via fin_stat R, 1 via scr_stat 1, 1 via pre_stat NS)
+    # 5 relays (2 scratched: 1 via fin_stat R, 1 via pre_stat R)
+    # Total splashes: 398 individual + 3 * 4 relay = 398 + 12 = 410 splashes (under limit)
     entry_with_scratches = []
     for i in range(1, 402):
         if i == 1:
@@ -607,13 +609,26 @@ def test_team_splashes_limit():
                     "fin_lane": 1,
                 }
             )
+        elif i == 3:
+            entry_with_scratches.append(
+                {
+                    "ath_no": i,
+                    "event_ptr": 1,
+                    "fin_time": 0.0,
+                    "fin_stat": "",
+                    "pre_stat": "NS",
+                    "fin_heat": 1,
+                    "fin_lane": 1,
+                }
+            )
         else:
             entry_with_scratches.append(
                 {"ath_no": i, "event_ptr": 1, "fin_time": 0.0, "fin_stat": "", "fin_heat": 1, "fin_lane": 1}
             )
 
-    relays_with_scratch = [{"team_ptr": 1, "event_ptr": 2, "fin_stat": ""} for _ in range(4)]
+    relays_with_scratch = [{"team_ptr": 1, "event_ptr": 2, "fin_stat": ""} for _ in range(3)]
     relays_with_scratch.append({"team_ptr": 1, "event_ptr": 2, "fin_stat": "R"})
+    relays_with_scratch.append({"team_ptr": 1, "event_ptr": 2, "pre_stat": "R"})
 
     cache_scratches = {
         "athlete": [

--- a/web-client/lib/scoreboard-sync/DataReceiver.js
+++ b/web-client/lib/scoreboard-sync/DataReceiver.js
@@ -1,0 +1,184 @@
+// DataReceiver.js - Google Apps Script
+// Deployed as a Web App (Run as: Me, Access: Anyone)
+
+const SHEET_NAME = "Scoreboard";
+const CACHE_KEY = "scoreboard_state";
+const CACHE_TTL_SEC = 1800; // 30 minutes cache life
+
+/**
+ * Helper to get the active scoreboard sheet.
+ */
+function getScoreboardSheet() {
+	const ss = SpreadsheetApp.getActiveSpreadsheet();
+	let sheet = ss.getSheetByName(SHEET_NAME);
+	if (!sheet) {
+		// Auto-create sheet if it doesn't exist
+		sheet = ss.insertSheet(SHEET_NAME);
+		sheet
+			.getRange("A1:C1")
+			.setValues([["Event", "Heat", "Last_Write_Timestamp"]]);
+		sheet.getRange("A2:C2").setValues([[1, 1, Date.now()]]);
+	}
+	return sheet;
+}
+
+/**
+ * Reads state from sheet and updates the cache.
+ */
+function getAndCacheState(sheet) {
+	const values = sheet.getRange("A2:C2").getValues()[0];
+	const state = {
+		event: Number(values[0]) || 1,
+		heat: Number(values[1]) || 1,
+		timestamp: Number(values[2]) || Date.now(),
+	};
+
+	const cache = CacheService.getScriptCache();
+	cache.put(CACHE_KEY, JSON.stringify(state), CACHE_TTL_SEC);
+	return state;
+}
+
+/**
+ * Handle GET request: read state.
+ */
+function _doGet(_e) {
+	const cache = CacheService.getScriptCache();
+	const cachedVal = cache.get(CACHE_KEY);
+
+	let state;
+	if (cachedVal) {
+		try {
+			state = JSON.parse(cachedVal);
+		} catch (_err) {
+			// If parsing fails, fall back to sheet
+			const sheet = getScoreboardSheet();
+			state = getAndCacheState(sheet);
+		}
+	} else {
+		// Cache miss - read from sheet
+		const sheet = getScoreboardSheet();
+		state = getAndCacheState(sheet);
+	}
+
+	return ContentService.createTextOutput(JSON.stringify(state)).setMimeType(
+		ContentService.MimeType.JSON,
+	);
+}
+
+/**
+ * Handle POST request: write state.
+ */
+function _doPost(e) {
+	const lock = LockService.getScriptLock();
+	try {
+		// Acquire lock for up to 5 seconds to prevent concurrent write collisions
+		if (!lock.tryLock(5000)) {
+			return ContentService.createTextOutput(
+				JSON.stringify({
+					success: false,
+					error: "Lock timeout: Another write operation is in progress.",
+				}),
+			).setMimeType(ContentService.MimeType.JSON);
+		}
+
+		// Parse request body
+		if (!e.postData?.contents) {
+			return ContentService.createTextOutput(
+				JSON.stringify({
+					success: false,
+					error: "Missing request body",
+				}),
+			).setMimeType(ContentService.MimeType.JSON);
+		}
+
+		const requestData = JSON.parse(e.postData.contents);
+		const newEvent = Number(requestData.event);
+		const newHeat = Number(requestData.heat);
+		const clientTimestamp = Number(requestData.timestamp) || Date.now();
+		const expectedTimestamp = Number(requestData.expectedTimestamp) || 0;
+
+		if (Number.isNaN(newEvent) || Number.isNaN(newHeat)) {
+			return ContentService.createTextOutput(
+				JSON.stringify({
+					success: false,
+					error: "Event and Heat must be valid numbers",
+				}),
+			).setMimeType(ContentService.MimeType.JSON);
+		}
+
+		const sheet = getScoreboardSheet();
+
+		// Concurrency Check: Read current state to see if updated elsewhere
+		const cache = CacheService.getScriptCache();
+		let currentState;
+		const cachedVal = cache.get(CACHE_KEY);
+		if (cachedVal) {
+			try {
+				currentState = JSON.parse(cachedVal);
+			} catch (_err) {
+				currentState = getAndCacheState(sheet);
+			}
+		} else {
+			currentState = getAndCacheState(sheet);
+		}
+
+		// If sheet state is newer than what client expected (and client passed an expectation), conflict!
+		if (expectedTimestamp > 0 && currentState.timestamp > expectedTimestamp) {
+			return ContentService.createTextOutput(
+				JSON.stringify({
+					success: false,
+					error: "Conflict",
+					code: 409,
+					currentState: currentState,
+				}),
+			).setMimeType(ContentService.MimeType.JSON);
+		}
+
+		// Write new state to the sheet
+		sheet.getRange("A2:C2").setValues([[newEvent, newHeat, clientTimestamp]]);
+
+		// Update cache immediately to keep reads fast and consistent
+		const updatedState = {
+			event: newEvent,
+			heat: newHeat,
+			timestamp: clientTimestamp,
+		};
+		cache.put(CACHE_KEY, JSON.stringify(updatedState), CACHE_TTL_SEC);
+
+		return ContentService.createTextOutput(
+			JSON.stringify({
+				success: true,
+				state: updatedState,
+			}),
+		).setMimeType(ContentService.MimeType.JSON);
+	} catch (err) {
+		return ContentService.createTextOutput(
+			JSON.stringify({
+				success: false,
+				error: err.toString(),
+			}),
+		).setMimeType(ContentService.MimeType.JSON);
+	} finally {
+		lock.releaseLock();
+	}
+}
+
+/**
+ * Handle manual edits on the spreadsheet directly.
+ * Clears or updates the cache when range A2:B2 is changed manually.
+ */
+function _onEdit(e) {
+	if (!e?.range) return;
+	const range = e.range;
+	const sheet = range.getSheet();
+
+	if (sheet.getName() === SHEET_NAME) {
+		const row = range.getRow();
+		const col = range.getColumn();
+
+		// Trigger if edit happens in A2 or B2
+		if (row === 2 && (col === 1 || col === 2)) {
+			getAndCacheState(sheet);
+		}
+	}
+}


### PR DESCRIPTION
Harmonize scratch checks for team splashes limit calculations by checking pre_stat for scratches, resolving an inconsistency identified during code review.