### PR TITLE
fix(desktop-build): enable devtools and override Node 24 env

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -15,6 +15,9 @@ on:
       - '.github/workflows/desktop-build.yml'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-desktop:
     strategy:

--- a/web-client/src-tauri/Cargo.toml
+++ b/web-client/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 base64 = "0.22.1"
-tauri = { version = "2.11.3", features = [] }
+tauri = { version = "2.11.3", features = ["devtools"] }
 tauri-plugin-log = "2"
 tauri-plugin-shell = "2.3.5"
 tauri-plugin-dialog = "2"


### PR DESCRIPTION
Enables the 'devtools' feature on the tauri dependency in web-client/src-tauri/Cargo.toml, allowing Playwright E2E tests to connect over CDP to the compiled release binary. Adds FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true env to the workflow to suppress Node 20 deprecation warnings.