### PR TITLE
fix(desktop-build): enable window devtools in config

### DIFF
--- a/web-client/src-tauri/tauri.conf.json
+++ b/web-client/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
 				"width": 1280,
 				"height": 800,
 				"resizable": true,
-				"fullscreen": false
+				"fullscreen": false,
+				"devtools": true
 			}
 		],
 		"security": {


### PR DESCRIPTION
Enables devtools: true in tauri.conf.json to allow remote WebView2 debugging in compiled production/release builds, resolving the Playwright E2E smoke test connection timeout.