### PR TITLE
fix(desktop-build): configure additionalBrowserArguments in tauri.conf.json

### DIFF
--- a/web-client/src-tauri/tauri.conf.json
+++ b/web-client/src-tauri/tauri.conf.json
@@ -18,7 +18,8 @@
 				"height": 800,
 				"resizable": true,
 				"fullscreen": false,
-				"devtools": true
+				"devtools": true,
+				"additionalBrowserArguments": "--remote-debugging-port=9223"
 			}
 		],
 		"security": {


### PR DESCRIPTION
Sets additionalBrowserArguments: --remote-debugging-port=9223 inside tauri.conf.json's window configuration. This ensures that WebView2 remote debugging is always initialized at the Tauri wrapper level rather than relying entirely on environment variables.