### PR TITLE
fix(desktop-build): isolate Windows WebView2 debugging arguments

### DIFF
--- a/web-client/src-tauri/tauri.conf.json
+++ b/web-client/src-tauri/tauri.conf.json
@@ -13,13 +13,13 @@
 		"withGlobalTauri": true,
 		"windows": [
 			{
+				"label": "main",
 				"title": "MeetManager Tools",
 				"width": 1280,
 				"height": 800,
 				"resizable": true,
 				"fullscreen": false,
-				"devtools": true,
-				"additionalBrowserArguments": "--remote-debugging-port=9223"
+				"devtools": true
 			}
 		],
 		"security": {

--- a/web-client/src-tauri/tauri.windows.conf.json
+++ b/web-client/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,10 @@
+{
+	"app": {
+		"windows": [
+			{
+				"label": "main",
+				"additionalBrowserArguments": "--remote-debugging-port=9223"
+			}
+		]
+	}
+}


### PR DESCRIPTION
Moves the additionalBrowserArguments setting to a Windows-specific configuration override file (tauri.windows.conf.json). This resolves the config validation compilation failure on macOS/Linux while ensuring the debugging port remains active on Windows for Playwright E2E tests.