### PR TITLE
fix(desktop-build): correct additionalBrowserArgs spelling

### DIFF
--- a/web-client/src-tauri/tauri.windows.conf.json
+++ b/web-client/src-tauri/tauri.windows.conf.json
@@ -3,7 +3,7 @@
 		"windows": [
 			{
 				"label": "main",
-				"additionalBrowserArguments": "--remote-debugging-port=9223"
+				"additionalBrowserArgs": "--remote-debugging-port=9223"
 			}
 		]
 	}


### PR DESCRIPTION
Corrects the option name from additionalBrowserArguments to additionalBrowserArgs in tauri.windows.conf.json to conform to the Tauri v2 configuration schema.